### PR TITLE
Unifying labels in ratings column

### DIFF
--- a/norare.tsv
+++ b/norare.tsv
@@ -1,9 +1,9 @@
 DATASET	NAME	STRUCTURE	TYPE	OTHER	NORARE	RATING	LANGUAGE	SOURCE	NOTE
-Bond-2013-OMW	IN_DEGREE	cardinality	hyperonym	in degree	relations	user	en		The number of hypernyms of a given concept.
-Bond-2013-OMW	OUT_DEGREE	cardinality	hyponym	out degree	relations	user	en		The number of hyponyms of a given concept.
-Alonso-2015-AoA	SPANISH_AOA_MEAN	mean	AoA		ratings	user	es		Average score of AoA ratings on a scale from 1 to 11.
-Alonso-2015-AoA	SPANISH_AOA_MIN	numeric	AoA	minimum	ratings	user	es		The minimum age of acquisition indicated by participants.
-Alonso-2015-AoA	SPANISH_AOA_MAX	numeric	AoA	maximum	ratings	user	es		The maximum age of acquisition indicated by participants.
+Bond-2013-OMW	IN_DEGREE	cardinality	hyperonym	in degree	relations	users	en		The number of hypernyms of a given concept.
+Bond-2013-OMW	OUT_DEGREE	cardinality	hyponym	out degree	relations	users	en		The number of hyponyms of a given concept.
+Alonso-2015-AoA	SPANISH_AOA_MEAN	mean	AoA		ratings	users	es		Average score of AoA ratings on a scale from 1 to 11.
+Alonso-2015-AoA	SPANISH_AOA_MIN	numeric	AoA	minimum	ratings	users	es		The minimum age of acquisition indicated by participants.
+Alonso-2015-AoA	SPANISH_AOA_MAX	numeric	AoA	maximum	ratings	users	es		The maximum age of acquisition indicated by participants.
 Brysbaert-2009-Frequency	ENGLISH_FREQUENCY	tokens	frequency		norms	corpus	en		The number of times the word appears in the corpus (i.e., on the total of 51 million words).
 Brysbaert-2009-Frequency	ENGLISH_CD	tokens	contextual diversity		norms	corpus	en		The number of films in which the word appears (i.e., it has a maximum value of 8,388).
 Brysbaert-2009-Frequency	ENGLISH_FREQUENCY_PM	numeric	frequency	per million	norms	corpus	en		The word frequency per million words. It is the measure one would preferably use in ones manuscripts, because it is a standard measure of word frequency independent of the corpus size. It is given with two-digit precision, in order not to lose precision of the frequency counts.
@@ -13,10 +13,10 @@ Brysbaert-2009-Frequency	ENGLISH_CD_LOG	logarithmic	contextual diversity		norms	
 Brysbaert-2011-Frequency	GERMAN_FREQUENCY	tokens	frequency		norms	corpus	de		This is the number of times the word as written in column 1 is encountered in the subtitle corpus.
 Brysbaert-2011-Frequency	GERMAN_FREQUENCY_PM	tokens	frequency	per million	norms	corpus	de		This is the frequency per million words based on CUMfreqcount (i.e., it equals CUMfreqcount / 25.399).
 Brysbaert-2011-Frequency	GERMAN_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	de		This is log10(CUMfreqcount+1). It is the value to use when you want to match stimuli in various conditions. When a stimulus is not present in the corpus, lgSUBTLEX gets a value of 0.
-Brysbaert-2014-Concreteness	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	user	en		The mean concreteness rating on a 5-point rating scale going from abstract to concrete.
-Brysbaert-2014-Concreteness	ENGLISH_DUNNO	cardinality	familiarity	dunno	ratings	user	en		The number of persons indicating they did not know the word.
-Brysbaert-2019-Prevalence	ENGLISH_KNOWN_PERCENTAGE	percentage	familiarity	known	ratings	user	en		The percentages of words known across 220,000 participants.
-Brysbaert-2019-Prevalence	ENGLISH_PREVALENCE	normalized	familiarity	prevalence	ratings	user	en		The word prevalence (number of people who know the word) across 220,000 participants.
+Brysbaert-2014-Concreteness	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	users	en		The mean concreteness rating on a 5-point rating scale going from abstract to concrete.
+Brysbaert-2014-Concreteness	ENGLISH_DUNNO	cardinality	familiarity	dunno	ratings	users	en		The number of persons indicating they did not know the word.
+Brysbaert-2019-Prevalence	ENGLISH_KNOWN_PERCENTAGE	percentage	familiarity	known	ratings	users	en		The percentages of words known across 220,000 participants.
+Brysbaert-2019-Prevalence	ENGLISH_PREVALENCE	normalized	familiarity	prevalence	ratings	users	en		The word prevalence (number of people who know the word) across 220,000 participants.
 Cai-2010-Frequency	CHINESE_FREQUENCY	tokens	frequency		norms	corpus	zh		The number of times the word appears in the corpus of 1.3 million words.
 Cai-2010-Frequency	CHINESE_FREQUENCY_PM	numeric	frequency	per million	norms	corpus	zh		The word frequency per million words. It is the measure one would preferably use in ones manuscripts, because it is a standard measure of word frequency independent of the corpus size. It is given with two-digit precision, in order not to lose precision of the frequency counts.
 Cai-2010-Frequency	CHINESE_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	zh		This value is based on log10(FREQcount+1) and has four-digit precision. Calculating the log frequency on the raw frequencies is the most straightforward transformation, because it allows one to give words that are not in the corpus a value of 0.
@@ -26,117 +26,117 @@ Cai-2010-Frequency	CHINESE_CD_LOG	logarithmic	contextual diversity		norms	corpus
 Cuetos-2011-Frequency	SPANISH_FREQUENCY	tokens	frequency		norms	corpus	es		This is the number of times the word appears in the corpus of 41 million words.
 Cuetos-2011-Frequency	SPANISH_FREQUENCY_PM	normalized	frequency	per million	norms	corpus	es		Word frequency per million of words.
 Cuetos-2011-Frequency	SPANISH_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	es		Log10 of subtitle word frequency.
-Desrochers-2009-SubjFrequency	FRENCH_SUBJECTIVE_FREQUENCY	mean	frequency	subjective	ratings	user	fr		Subjective frequencies estimates were based on a 7-point rating scale.
-Desrochers-2009-SubjFrequency	FRENCH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	fr		Imageability estimates were based on a 7-point rating scale.
-Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN	mean	humor		ratings	user	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for all participants.
-Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_MALE	mean	humor	male	ratings	user	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for male participants.
-Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_FEMALE	mean	humor	female	ratings	user	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for female participants.
-Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_YOUNG	mean	humor	young	ratings	user	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for young participants (with age above 32).
-Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_OLD	mean	humor	old	ratings	user	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for old participants (with age under 32).
-Juhasz-2013-SER	ENGLISH_SER_MEAN	mean	sensory experience		ratings	user	en		Sensory experience ratings on a 7-point scale.
+Desrochers-2009-SubjFrequency	FRENCH_SUBJECTIVE_FREQUENCY	mean	frequency	subjective	ratings	users	fr		Subjective frequencies estimates were based on a 7-point rating scale.
+Desrochers-2009-SubjFrequency	FRENCH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	fr		Imageability estimates were based on a 7-point rating scale.
+Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN	mean	humor		ratings	users	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for all participants.
+Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_MALE	mean	humor	male	ratings	users	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for male participants.
+Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_FEMALE	mean	humor	female	ratings	users	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for female participants.
+Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_YOUNG	mean	humor	young	ratings	users	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for young participants (with age above 32).
+Engelthaler-2018-Humor	ENGLISH_HUMOR_MEAN_OLD	mean	humor	old	ratings	users	en		This is the mean value of the ratings on a 5-point scale (1 (humorless) to 5 (humorous)) for old participants (with age under 32).
+Juhasz-2013-SER	ENGLISH_SER_MEAN	mean	sensory experience		ratings	users	en		Sensory experience ratings on a 7-point scale.
 Keuleers-2010-Frequency	DUTCH_FREQUENCY	tokens	frequency		norms	corpus	nl		This is the number of times the word appears in the corpus of 42 million words.
 Keuleers-2010-Frequency	DUTCH_CD	tokens	contextual diversity		norms	corpus	nl		This  is the number of films in which the word appears.
 Keuleers-2010-Frequency	DUTCH_FREQUENCY_PM	tokens	frequency	per million	norms	corpus	nl		This is the word frequency per million words and has 4-digit precision.
 Keuleers-2010-Frequency	DUTCH_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	nl		This is a value based on log10(FREQcount+1) and with 4-digit precision.
 Keuleers-2010-Frequency	DUTCH_SUBTITLE_CD	numeric	contextual diversity	subtitle	norms	corpus	nl		This value indicates in what percent of the films the word appears (on a maximum of 8,070), with 4-digit precision.
 Keuleers-2010-Frequency	DUTCH_CD_LOG	logarithmic	contextual diversity		norms	corpus	nl		This value is based on log10(CDcount +1) and has 4-digit precision.
-Kuperman-2012-AoA	ENGLISH_OCCURRENCES_TOTAL	numeric	AoA	total	ratings	user	en		This is the number of valid age of acquisition-ratings of the word in the trimmed data.
-Kuperman-2012-AoA	ENGLISH_OCCURRENCES_NUM	numeric	AoA	number	ratings	user	en		This is the number of valid age of acquisition-ratings of the word, counting only numeric ratings, not 'don't know's.
-Kuperman-2012-AoA	ENGLISH_AOA_MEAN	mean	AoA		ratings	user	en		This is the mean of the age of acquisition-ratings of the word. A total of 696,048 valid ratings, including 76,211 'don't know's, were collected from 1,729 inhabitants of the US. For each word, the participants were asked to enter the age (in years) at which they thought they had learned the word.
-Kuperman-2012-AoA	ENGLISH_DUNNO	percentage	familiarity	dunno	ratings	user	en		This is the proportion of valid responses that are a rating and not a 'don't know'.
-Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	user	pl		This is the mean of the valence ratings for each word obtained in the group of men on a 7-point scale (with -3 the lowest and +3 the highest value).
-Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	user	pl		This is the mean of the valence ratings for each word obtained in the group of women on a 7-point scale (with -3 the lowest and +3 the highest value).
-Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN	mean	valence		ratings	user	pl		This is the mean of the valence ratings for each word obtained in the whole group on a 7-point scale (with -3 the lowest and +3 the highest value).
-Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	user	pl		This is the mean of the arousal ratings for each word obtained in the group of men on a 5-point scale indicated by a SAM scale.
-Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	user	pl		This is the mean of the arousal ratings for each word obtained in the group of women on a 7-point scale.
-Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN	mean	arousal		ratings	user	pl		This is the mean of the arousal ratings for each word obtained in the whole group on a 5-point scale indicated by a SAM scale.
-Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN_MALE	mean	imageability	male	ratings	user	pl		This is the mean of the imageability ratings for each word obtained in the group of men on a 5-point scale indicated by a SAM scale.
-Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN_FEMALE	mean	imageability	female	ratings	user	pl		This is the mean of the imageanility ratings for each word obtained in the group of women on a 7-point scale.
-Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	pl		This is the mean of the imageability ratings for each word obtained in the whole group on a 7-point scale.
-Scott-2019-Ratings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	user	en		Number of Scale Points: 9 Arousal is a measure of excitement versus calmness.
-Scott-2019-Ratings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	user	en		Number of Scale Points: 9 Valence is a measure of value or worth.
-Scott-2019-Ratings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	user	en		Number of Scale Points: 9 Dominance is a measure of the degree of control you feel.
-Scott-2019-Ratings	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	user	en		Number of Scale Points: 7 Concreteness is a measure of how concrete or abstract something is. A word is CONCRETE if it represents something that exists in a definite physical form in the real world. In contrast, a word is ABSTRACT if it represents more of a concept or idea.
-Scott-2019-Ratings	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	en		Number of Scale Points: 7 Imageability is a measure of how easy or difficult something is to imagine.
-Scott-2019-Ratings	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	user	en		Number of Scale Points: 7 Familiarity is a measure of how familiar something is.
-Scott-2019-Ratings	ENGLISH_AOA_MEAN	mean	AoA		ratings	user	en		Number of Scale Points: 7 A words age of acquisition is the age at which that word was initially learned.
-Scott-2019-Ratings	ENGLISH_SEM_SIZE_MEAN	mean	semantic size		ratings	user	en		Number of Scale Points: 7 Size is a measure of somethings dimensions, magnitude, or extent. A word represents something BIG if it refers to things or concepts that are large. A word represents something SMALL if it refers to things or concepts that are little.
-Scott-2019-Ratings	ENGLISH_GENDER_ASSOCIATION_MEAN	mean	gender association		ratings	user	en		Number of Scale Points: 7 A words gender is how strongly its meaning is associated with male or female behaviour.
-StadthagenGonzalez-2017-ValenceArousal	SPANISH_VALENCE_MEAN	mean	valence		ratings	user	es		This is the mean value of valence across all participants. Participants rated the words on a 9-point scale.
-StadthagenGonzalez-2017-ValenceArousal	SPANISH_AROUSAL_MEAN	mean	arousal		ratings	user	es		This is the mean value of arousal across all participants. Participants rated the words on a 9-point scale.
+Kuperman-2012-AoA	ENGLISH_OCCURRENCES_TOTAL	numeric	AoA	total	ratings	users	en		This is the number of valid age of acquisition-ratings of the word in the trimmed data.
+Kuperman-2012-AoA	ENGLISH_OCCURRENCES_NUM	numeric	AoA	number	ratings	users	en		This is the number of valid age of acquisition-ratings of the word, counting only numeric ratings, not 'don't know's.
+Kuperman-2012-AoA	ENGLISH_AOA_MEAN	mean	AoA		ratings	users	en		This is the mean of the age of acquisition-ratings of the word. A total of 696,048 valid ratings, including 76,211 'don't know's, were collected from 1,729 inhabitants of the US. For each word, the participants were asked to enter the age (in years) at which they thought they had learned the word.
+Kuperman-2012-AoA	ENGLISH_DUNNO	percentage	familiarity	dunno	ratings	users	en		This is the proportion of valid responses that are a rating and not a 'don't know'.
+Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	users	pl		This is the mean of the valence ratings for each word obtained in the group of men on a 7-point scale (with -3 the lowest and +3 the highest value).
+Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	users	pl		This is the mean of the valence ratings for each word obtained in the group of women on a 7-point scale (with -3 the lowest and +3 the highest value).
+Riegel-2015-AffectiveRatings	POLISH_VALENCE_MEAN	mean	valence		ratings	users	pl		This is the mean of the valence ratings for each word obtained in the whole group on a 7-point scale (with -3 the lowest and +3 the highest value).
+Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	users	pl		This is the mean of the arousal ratings for each word obtained in the group of men on a 5-point scale indicated by a SAM scale.
+Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	users	pl		This is the mean of the arousal ratings for each word obtained in the group of women on a 7-point scale.
+Riegel-2015-AffectiveRatings	POLISH_AROUSAL_MEAN	mean	arousal		ratings	users	pl		This is the mean of the arousal ratings for each word obtained in the whole group on a 5-point scale indicated by a SAM scale.
+Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN_MALE	mean	imageability	male	ratings	users	pl		This is the mean of the imageability ratings for each word obtained in the group of men on a 5-point scale indicated by a SAM scale.
+Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN_FEMALE	mean	imageability	female	ratings	users	pl		This is the mean of the imageanility ratings for each word obtained in the group of women on a 7-point scale.
+Riegel-2015-AffectiveRatings	POLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	pl		This is the mean of the imageability ratings for each word obtained in the whole group on a 7-point scale.
+Scott-2019-Ratings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	users	en		Number of Scale Points: 9 Arousal is a measure of excitement versus calmness.
+Scott-2019-Ratings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	users	en		Number of Scale Points: 9 Valence is a measure of value or worth.
+Scott-2019-Ratings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	users	en		Number of Scale Points: 9 Dominance is a measure of the degree of control you feel.
+Scott-2019-Ratings	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	users	en		Number of Scale Points: 7 Concreteness is a measure of how concrete or abstract something is. A word is CONCRETE if it represents something that exists in a definite physical form in the real world. In contrast, a word is ABSTRACT if it represents more of a concept or idea.
+Scott-2019-Ratings	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	en		Number of Scale Points: 7 Imageability is a measure of how easy or difficult something is to imagine.
+Scott-2019-Ratings	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	users	en		Number of Scale Points: 7 Familiarity is a measure of how familiar something is.
+Scott-2019-Ratings	ENGLISH_AOA_MEAN	mean	AoA		ratings	users	en		Number of Scale Points: 7 A words age of acquisition is the age at which that word was initially learned.
+Scott-2019-Ratings	ENGLISH_SEM_SIZE_MEAN	mean	semantic size		ratings	users	en		Number of Scale Points: 7 Size is a measure of somethings dimensions, magnitude, or extent. A word represents something BIG if it refers to things or concepts that are large. A word represents something SMALL if it refers to things or concepts that are little.
+Scott-2019-Ratings	ENGLISH_GENDER_ASSOCIATION_MEAN	mean	gender association		ratings	users	en		Number of Scale Points: 7 A words gender is how strongly its meaning is associated with male or female behaviour.
+StadthagenGonzalez-2017-ValenceArousal	SPANISH_VALENCE_MEAN	mean	valence		ratings	users	es		This is the mean value of valence across all participants. Participants rated the words on a 9-point scale.
+StadthagenGonzalez-2017-ValenceArousal	SPANISH_AROUSAL_MEAN	mean	arousal		ratings	users	es		This is the mean value of arousal across all participants. Participants rated the words on a 9-point scale.
 Starostin-2000-Sense	SENSES	linguistic	sense relation		relations	other	en		The relations to a sense for a given word.
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	user	en		Mean value of valence ratings on a 9-point scale across all participants.
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	user	en		Mean value of arousal ratings on a 9-point scale across all participants.
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	user	en		Mean value of dominance ratings on a 9-point scale across all participants.
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	user	en		Mean value of valence ratings on a 9-point scale across male participants.
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	user	en		Mean value of valence ratings on a 9-point scale across female participants.
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	user	en		Mean value of arousal ratings on a 9-point scale across male participants.
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	user	en		Mean value of arousal ratings on a 9-point scale across female participants.
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_MALE	mean	dominance	male	ratings	user	en		Mean value of dominance ratings on a 9-point scale across male participants.
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_FEMALE	mean	dominance	female	ratings	user	en		Mean value of dominance ratings on a 9-point scale across female participants.
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_YOUNG	mean	valence	young	ratings	user	en		Mean value of valence ratings on a 9-point scale across young participants (less than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_OLD	mean	valence	old	ratings	user	en		Mean value of valence ratings on a 9-point scale across old participants (greater than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_YOUNG	mean	arousal	young	ratings	user	en		Mean value of arousal ratings on a 9-point scale across young participants (less than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_OLD	mean	arousal	old	ratings	user	en		Mean value of arousal ratings on a 9-point scale across old participants (greater than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_YOUNG	mean	dominance	young	ratings	user	en		Mean value of dominance ratings on a 9-point scale across young participants (less than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_OLD	mean	dominance	old	ratings	user	en		Mean value of dominance ratings on a 9-point scale across old participants (greater than 30 years old).
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_HIGH	mean	valence	high education	ratings	user	en		Mean value of valence ratings on a 9-point scale across participants with a high education.
-Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_LOW	mean	valence	low education	ratings	user	en		Mean value of valence ratings on a 9-point scale across participants with a low education.
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_HIGH	mean	arousal	high education	ratings	user	en		Mean value of arousal ratings on a 9-point scale across participants with a high education.
-Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_LOW	mean	arousal	low education	ratings	user	en		Mean value of arousal ratings on a 9-point scale across participants with a low education.
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_HIGH	mean	dominance	high education	ratings	user	en		Mean value of dominance ratings on a 9-point scale across participants with a high education.
-Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_LOW	mean	dominance	low education	ratings	user	en		Mean value of dominance ratings on a 9-point scale across participants with a low education.
-Cortese-2008-AoA	ENGLISH_AOA_MEAN	mean	AoA		ratings	user	en		This is the mean value of age-of-acquisition ratings on a 7-point scale.
-Keuleers-2012-LexicalDecision	ENGLISH_RT_MEAN	mean	lexical decision	reaction time	norms	user	en		The average reaction time to the stimulus (correct trials only).
-Keuleers-2012-LexicalDecision	ENGLISH_RT_ZSCORE	standardized	lexical decision	reaction time	norms	user	en		The average standardized reaction time (RT). Standardized RTs were calculated separately for all levels of participant, block, and lexicality (e.g., all RTs to correct word trials in block 1 by participant 1).
-Keuleers-2012-LexicalDecision	ENGLISH_ACCURACY_PERCENTAGE	percentage	lexical decision	accuracy	norms	user	en		Average accuracy for the stimulus.
-Ferrand-2010-LexicalDecision	FRENCH_RT_MEAN	mean	lexical decision	reaction time	norms	user	fr		The average reaction time to the stimulus (correct trials only).
-Ferrand-2010-LexicalDecision	FRENCH_RT_ZSCORE	standardized	lexical decision	reaction time	norms	user	fr		The average standardized reaction time (RT). Standardized RTs were calculated separately for all levels of participant, block, and lexicality (e.g., all RTs to correct word trials in block 1 by participant 1).
-GonzalezNosti-2014-LexicalDecision	SPANISH_AOA_MEAN	mean	AoA		ratings	user	es		Mean value of AoA ratings on a 7-point Likert scale in which 1 corresponded to ages between 0 and 2 years old, 2 to ages between 2 and 4, and so on up to 7, which corresponded to ages over 12 years old.
-GonzalezNosti-2014-LexicalDecision	SPANISH_RT_MEAN	mean	lexical decision	reaction time	norms	user	es		The average reaction time to the stimulus (correct trials only).
-Tsang-2018-LexicalDecision	CHINESE_RT_MEAN	mean	lexical decision	reaction time	norms	user	zh		Mean reaction time across participants.
-Tsang-2018-LexicalDecision	CHINESE_RT_ZSCORE	standardized	lexical decision	reaction time	norms	user	zh		Mean standardized reaction time across participants.
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	users	en		Mean value of valence ratings on a 9-point scale across all participants.
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	users	en		Mean value of arousal ratings on a 9-point scale across all participants.
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	users	en		Mean value of dominance ratings on a 9-point scale across all participants.
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	users	en		Mean value of valence ratings on a 9-point scale across male participants.
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	users	en		Mean value of valence ratings on a 9-point scale across female participants.
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	users	en		Mean value of arousal ratings on a 9-point scale across male participants.
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	users	en		Mean value of arousal ratings on a 9-point scale across female participants.
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_MALE	mean	dominance	male	ratings	users	en		Mean value of dominance ratings on a 9-point scale across male participants.
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_FEMALE	mean	dominance	female	ratings	users	en		Mean value of dominance ratings on a 9-point scale across female participants.
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_YOUNG	mean	valence	young	ratings	users	en		Mean value of valence ratings on a 9-point scale across young participants (less than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_OLD	mean	valence	old	ratings	users	en		Mean value of valence ratings on a 9-point scale across old participants (greater than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_YOUNG	mean	arousal	young	ratings	users	en		Mean value of arousal ratings on a 9-point scale across young participants (less than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_OLD	mean	arousal	old	ratings	users	en		Mean value of arousal ratings on a 9-point scale across old participants (greater than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_YOUNG	mean	dominance	young	ratings	users	en		Mean value of dominance ratings on a 9-point scale across young participants (less than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_OLD	mean	dominance	old	ratings	users	en		Mean value of dominance ratings on a 9-point scale across old participants (greater than 30 years old).
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_HIGH	mean	valence	high education	ratings	users	en		Mean value of valence ratings on a 9-point scale across participants with a high education.
+Warriner-2013-AffectiveRatings	ENGLISH_VALENCE_MEAN_LOW	mean	valence	low education	ratings	users	en		Mean value of valence ratings on a 9-point scale across participants with a low education.
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_HIGH	mean	arousal	high education	ratings	users	en		Mean value of arousal ratings on a 9-point scale across participants with a high education.
+Warriner-2013-AffectiveRatings	ENGLISH_AROUSAL_MEAN_LOW	mean	arousal	low education	ratings	users	en		Mean value of arousal ratings on a 9-point scale across participants with a low education.
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_HIGH	mean	dominance	high education	ratings	users	en		Mean value of dominance ratings on a 9-point scale across participants with a high education.
+Warriner-2013-AffectiveRatings	ENGLISH_DOMINANCE_MEAN_LOW	mean	dominance	low education	ratings	users	en		Mean value of dominance ratings on a 9-point scale across participants with a low education.
+Cortese-2008-AoA	ENGLISH_AOA_MEAN	mean	AoA		ratings	users	en		This is the mean value of age-of-acquisition ratings on a 7-point scale.
+Keuleers-2012-LexicalDecision	ENGLISH_RT_MEAN	mean	lexical decision	reaction time	norms	users	en		The average reaction time to the stimulus (correct trials only).
+Keuleers-2012-LexicalDecision	ENGLISH_RT_ZSCORE	standardized	lexical decision	reaction time	norms	users	en		The average standardized reaction time (RT). Standardized RTs were calculated separately for all levels of participant, block, and lexicality (e.g., all RTs to correct word trials in block 1 by participant 1).
+Keuleers-2012-LexicalDecision	ENGLISH_ACCURACY_PERCENTAGE	percentage	lexical decision	accuracy	norms	users	en		Average accuracy for the stimulus.
+Ferrand-2010-LexicalDecision	FRENCH_RT_MEAN	mean	lexical decision	reaction time	norms	users	fr		The average reaction time to the stimulus (correct trials only).
+Ferrand-2010-LexicalDecision	FRENCH_RT_ZSCORE	standardized	lexical decision	reaction time	norms	users	fr		The average standardized reaction time (RT). Standardized RTs were calculated separately for all levels of participant, block, and lexicality (e.g., all RTs to correct word trials in block 1 by participant 1).
+GonzalezNosti-2014-LexicalDecision	SPANISH_AOA_MEAN	mean	AoA		ratings	users	es		Mean value of AoA ratings on a 7-point Likert scale in which 1 corresponded to ages between 0 and 2 years old, 2 to ages between 2 and 4, and so on up to 7, which corresponded to ages over 12 years old.
+GonzalezNosti-2014-LexicalDecision	SPANISH_RT_MEAN	mean	lexical decision	reaction time	norms	users	es		The average reaction time to the stimulus (correct trials only).
+Tsang-2018-LexicalDecision	CHINESE_RT_MEAN	mean	lexical decision	reaction time	norms	users	zh		Mean reaction time across participants.
+Tsang-2018-LexicalDecision	CHINESE_RT_ZSCORE	standardized	lexical decision	reaction time	norms	users	zh		Mean standardized reaction time across participants.
 Tsang-2018-LexicalDecision	CHINESE_STROKE	cardinality	strokes		norms	meta	zh		Total number of strokes of the whole-word.
-Keuleers-2015-Prevalence	DUTCH_ACCURACY_PERCENTAGE	percentage	familiarity	accuracy	ratings	user	nl		Average accuracy for the stimulus.
-Keuleers-2015-Prevalence	DUTCH_PREVALENCE	normalized	familiarity	prevalence	ratings	user	nl		The word prevalence (number of people who know the word) across nearly 300,000 participants.
-StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_HAPPINESS_MEAN	mean	happiness		ratings	user	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category happiness.
-StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_DISGUST_MEAN	mean	disgust		ratings	user	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category disgust.
-StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_ANGER_MEAN	mean	anger		ratings	user	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category anger.
-StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_FEAR_MEAN	mean	fear		ratings	user	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category fear.
-StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_SADNESS_MEAN	mean	sadness		ratings	user	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category sadness.
-Alonso-2016-AoA	SPANISH_AOA_MEAN	mean	AoA		ratings	user	es		Average score of AoA ratings. A predefined age scale was not used, and participants were required to directly enter the number corresponding to a particular age, in years.
-Alonso-2016-AoA	SPANISH_AOA_MIN	numeric	AoA	minimum	ratings	user	es		The minimum age of acquisition indicated by participants.
-Alonso-2016-AoA	SPANISH_AOA_MAX	numeric	AoA	maximum	ratings	user	es		The maximum age of acquisition indicated by participants.
-Alonso-2016-AoA	SPANISH_AOA_ZSCORE	standardized	AoA	z-score	ratings	user	es		The average standardized AoA ratings.
-Imbir-2021-Ratings	POLISH_VALENCE_MEAN	mean	valence		ratings	user	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_AROUSAL_MEAN	mean	arousal		ratings	user	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN	mean	dominance		ratings	user	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_ORIGIN_MEAN	mean	origin		ratings	user	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN	mean	significance		ratings	user	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	user	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across all participants.
-Imbir-2021-Ratings	POLISH_AOA_MEAN	mean	AoA		ratings	user	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across all participants.
-Imbir-2021-Ratings	POLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	user	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	user	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN_FEMALE	mean	dominance	female	ratings	user	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_ORIGIN_MEAN_FEMALE	mean	origin	female	ratings	user	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN_FEMALE	mean	significance	female	ratings	user	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN_FEMALE	mean	concreteness	female	ratings	user	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN_FEMALE	mean	imageability	female	ratings	user	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across female participants.
-Imbir-2021-Ratings	POLISH_AOA_MEAN_FEMALE	mean	AoA	female	ratings	user	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across female participants.
-Imbir-2021-Ratings	POLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	user	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	user	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN_MALE	mean	dominance	male	ratings	user	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_ORIGIN_MEAN_MALE	mean	origin	male	ratings	user	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN_MALE	mean	significance	male	ratings	user	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN_MALE	mean	concreteness	male	ratings	user	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN_MALE	mean	imageability	male	ratings	user	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across male participants.
-Imbir-2021-Ratings	POLISH_AOA_MEAN_MALE	mean	AoA	male	ratings	user	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across male participants.
-Ferre-2017-DiscreteEmotions	SPANISH_HAPPINESS_MEAN	mean	happiness		ratings	user	es		The mean value of the ratings for the discrete emotion happiness on a 5-point scale.
-Ferre-2017-DiscreteEmotions	SPANISH_ANGER_MEAN	mean	anger		ratings	user	es		The mean value of the ratings for the discrete emotion anger on a 5-point scale.
-Ferre-2017-DiscreteEmotions	SPANISH_SADNESS_MEAN	mean	sadness		ratings	user	es		The mean value of the ratings for the discrete emotion sadness on a 5-point scale.
-Ferre-2017-DiscreteEmotions	SPANISH_FEAR_MEAN	mean	fear		ratings	user	es		The mean value of the ratings for the discrete emotion fear on a 5-point scale.
-Ferre-2017-DiscreteEmotions	SPANISH_DISGUST_MEAN	mean	disgust		ratings	user	es		The mean value of the ratings for the discrete emotion disgust on a 5-point scale.
+Keuleers-2015-Prevalence	DUTCH_ACCURACY_PERCENTAGE	percentage	familiarity	accuracy	ratings	users	nl		Average accuracy for the stimulus.
+Keuleers-2015-Prevalence	DUTCH_PREVALENCE	normalized	familiarity	prevalence	ratings	users	nl		The word prevalence (number of people who know the word) across nearly 300,000 participants.
+StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_HAPPINESS_MEAN	mean	happiness		ratings	users	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category happiness.
+StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_DISGUST_MEAN	mean	disgust		ratings	users	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category disgust.
+StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_ANGER_MEAN	mean	anger		ratings	users	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category anger.
+StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_FEAR_MEAN	mean	fear		ratings	users	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category fear.
+StadthagenGonzalez-2018-DiscreteEmotions	SPANISH_SADNESS_MEAN	mean	sadness		ratings	users	es		Mean value for all valid responses a 5-point scale with 1 (not at all) and 5 (extremely) in the emotional category sadness.
+Alonso-2016-AoA	SPANISH_AOA_MEAN	mean	AoA		ratings	users	es		Average score of AoA ratings. A predefined age scale was not used, and participants were required to directly enter the number corresponding to a particular age, in years.
+Alonso-2016-AoA	SPANISH_AOA_MIN	numeric	AoA	minimum	ratings	users	es		The minimum age of acquisition indicated by participants.
+Alonso-2016-AoA	SPANISH_AOA_MAX	numeric	AoA	maximum	ratings	users	es		The maximum age of acquisition indicated by participants.
+Alonso-2016-AoA	SPANISH_AOA_ZSCORE	standardized	AoA	z-score	ratings	users	es		The average standardized AoA ratings.
+Imbir-2021-Ratings	POLISH_VALENCE_MEAN	mean	valence		ratings	users	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_AROUSAL_MEAN	mean	arousal		ratings	users	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN	mean	dominance		ratings	users	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_ORIGIN_MEAN	mean	origin		ratings	users	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN	mean	significance		ratings	users	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	users	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across all participants.
+Imbir-2021-Ratings	POLISH_AOA_MEAN	mean	AoA		ratings	users	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across all participants.
+Imbir-2021-Ratings	POLISH_VALENCE_MEAN_FEMALE	mean	valence	female	ratings	users	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_AROUSAL_MEAN_FEMALE	mean	arousal	female	ratings	users	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN_FEMALE	mean	dominance	female	ratings	users	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_ORIGIN_MEAN_FEMALE	mean	origin	female	ratings	users	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN_FEMALE	mean	significance	female	ratings	users	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN_FEMALE	mean	concreteness	female	ratings	users	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN_FEMALE	mean	imageability	female	ratings	users	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across female participants.
+Imbir-2021-Ratings	POLISH_AOA_MEAN_FEMALE	mean	AoA	female	ratings	users	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across female participants.
+Imbir-2021-Ratings	POLISH_VALENCE_MEAN_MALE	mean	valence	male	ratings	users	pl		Mean value of valence ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_AROUSAL_MEAN_MALE	mean	arousal	male	ratings	users	pl		Mean value of arousal ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_DOMINANCE_MEAN_MALE	mean	dominance	male	ratings	users	pl		Mean value of dominance ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_ORIGIN_MEAN_MALE	mean	origin	male	ratings	users	pl		Mean value of origin ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_SIGNIFICANCE_MEAN_MALE	mean	significance	male	ratings	users	pl		Mean value of significance ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_CONCRETENESS_MEAN_MALE	mean	concreteness	male	ratings	users	pl		Mean value of concreteness ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_IMAGEABILITY_MEAN_MALE	mean	imageability	male	ratings	users	pl		Mean value of imageability ratings on a SAM scale underlaid with a 9-point scale across male participants.
+Imbir-2021-Ratings	POLISH_AOA_MEAN_MALE	mean	AoA	male	ratings	users	pl		Mean value of age-of-acquisition ratings on a SAM scale underlaid with a 3-18 scale across male participants.
+Ferre-2017-DiscreteEmotions	SPANISH_HAPPINESS_MEAN	mean	happiness		ratings	users	es		The mean value of the ratings for the discrete emotion happiness on a 5-point scale.
+Ferre-2017-DiscreteEmotions	SPANISH_ANGER_MEAN	mean	anger		ratings	users	es		The mean value of the ratings for the discrete emotion anger on a 5-point scale.
+Ferre-2017-DiscreteEmotions	SPANISH_SADNESS_MEAN	mean	sadness		ratings	users	es		The mean value of the ratings for the discrete emotion sadness on a 5-point scale.
+Ferre-2017-DiscreteEmotions	SPANISH_FEAR_MEAN	mean	fear		ratings	users	es		The mean value of the ratings for the discrete emotion fear on a 5-point scale.
+Ferre-2017-DiscreteEmotions	SPANISH_DISGUST_MEAN	mean	disgust		ratings	users	es		The mean value of the ratings for the discrete emotion disgust on a 5-point scale.
 Rzymski-2020-1624	FAMILY_FREQUENCY	cardinality	polysemy	family	relations	concept lists	en		This is the number of times a translation for a given concept occurs across language families.
 Rzymski-2020-1624	LANGUAGE_FREQUENCY	cardinality	polysemy	language	relations	concept lists	en		This is the number of times a translation for a given concept occurs across language varieties.
 Rzymski-2020-1624	WORD_FREQUENCY	cardinality	polysemy	word	relations	concept lists	en		This is the number of times a translation for a given concept occurs for a given word.
@@ -146,221 +146,221 @@ Rzymski-2020-1624	CENTRAL_CONCEPT	numeric	polysemy	central concept	relations	con
 Rzymski-2020-1624	DEGREE	numeric	polysemy	degree	relations	concept lists	en		This is the unweighted and weighted degree for each node.
 Rzymski-2020-1624	WEIGHTED_FAMILY_DEGREE	numeric	polysemy	weighted family degree	relations	concept lists	en		This is the weighted degree for each node across language families.
 Rzymski-2020-1624	WEIGHTED_LANGUAGE_DEGREE	numeric	polysemy	weighted language degree	relations	concept lists	en		This is the weighted degree for each node across language varieties.
-Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN	mean	happiness		ratings	user	pl		Mean value for all valid responses on a 7-point scale in the emotional category happiness.
-Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN	mean	anger		ratings	user	pl		Mean value for all valid responses on a 7-point scale in the emotional category anger.
-Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN	mean	sadness		ratings	user	pl		Mean value for all valid responses on a 7-point scale in the emotional category sadness.
-Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN	mean	fear		ratings	user	pl		Mean value for all valid responses on a 7-point scale in the emotional category fear.
-Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN	mean	disgust		ratings	user	pl		Mean value for all valid responses on a 7-point scale in the emotional category disgust.
-Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN_FEMALE	mean	happiness	female	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category happiness (only female participants).
-Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN_FEMALE	mean	anger	female	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category anger (only female participants).
-Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN_FEMALE	mean	sadness	female	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category sadness(only female participants).
-Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN_FEMALE	mean	fear	female	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category fear (only female participants).
-Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN_FEMALE	mean	disgust	female	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category disgust (only female participants).
-Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN_MALE	mean	happiness	male	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category happiness (only male participants).
-Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN_MALE	mean	anger	male	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category anger (only male participants).
-Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN_MALE	mean	sadness	male	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category sadness(only male participants).
-Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN_MALE	mean	fear	male	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category fear (only male participants).
-Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN_MALE	mean	disgust	male	ratings	user	pl		Mean value for ratings on a 7-point scale in the emotional category disgust (only male participants).
+Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN	mean	happiness		ratings	users	pl		Mean value for all valid responses on a 7-point scale in the emotional category happiness.
+Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN	mean	anger		ratings	users	pl		Mean value for all valid responses on a 7-point scale in the emotional category anger.
+Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN	mean	sadness		ratings	users	pl		Mean value for all valid responses on a 7-point scale in the emotional category sadness.
+Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN	mean	fear		ratings	users	pl		Mean value for all valid responses on a 7-point scale in the emotional category fear.
+Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN	mean	disgust		ratings	users	pl		Mean value for all valid responses on a 7-point scale in the emotional category disgust.
+Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN_FEMALE	mean	happiness	female	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category happiness (only female participants).
+Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN_FEMALE	mean	anger	female	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category anger (only female participants).
+Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN_FEMALE	mean	sadness	female	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category sadness(only female participants).
+Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN_FEMALE	mean	fear	female	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category fear (only female participants).
+Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN_FEMALE	mean	disgust	female	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category disgust (only female participants).
+Wierzba-2015-DiscreteEmotions	POLISH_HAPPINESS_MEAN_MALE	mean	happiness	male	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category happiness (only male participants).
+Wierzba-2015-DiscreteEmotions	POLISH_ANGER_MEAN_MALE	mean	anger	male	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category anger (only male participants).
+Wierzba-2015-DiscreteEmotions	POLISH_SADNESS_MEAN_MALE	mean	sadness	male	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category sadness(only male participants).
+Wierzba-2015-DiscreteEmotions	POLISH_FEAR_MEAN_MALE	mean	fear	male	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category fear (only male participants).
+Wierzba-2015-DiscreteEmotions	POLISH_DISGUST_MEAN_MALE	mean	disgust	male	ratings	users	pl		Mean value for ratings on a 7-point scale in the emotional category disgust (only male participants).
 Alonso-2011-OralFrequency	SPANISH_FREQUENCY	tokens	frequency		norms	corpus	es		This is the number of times the spoken word appears in the corpus of 10 million words.
 Alonso-2011-OralFrequency	SPANISH_FREQUENCY_PM	normalized	frequency	per million	norms	corpus	es		The frequency per million for spoken words.
 Alonso-2011-OralFrequency	SPANISH_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	es		The log10 of spoken word frequency.
-Lynott-2020-Sensorimotor	ENGLISH_AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	en		Auditory strength: mean rating (0–5) of how strongly the concept is experienced by hearing.
-Lynott-2020-Sensorimotor	ENGLISH_GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	en		Gustatory strength: mean rating (0–5) of how strongly the concept is experienced by tasting.
-Lynott-2020-Sensorimotor	ENGLISH_HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	en		Haptic strength: mean rating (0–5) of how strongly the concept is experienced by feeling through touch.
-Lynott-2020-Sensorimotor	ENGLISH_INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	user	en		Interoceptive strength: mean rating (0–5) of how strongly the concept is experienced by sensations inside the body.
-Lynott-2020-Sensorimotor	ENGLISH_OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	en		Olfactory strength: mean rating (0–5) of how strongly the concept is experienced by smelling.
-Lynott-2020-Sensorimotor	ENGLISH_VISUAL_MEAN	mean	sensory modality	visual	ratings	user	en		Visual strength: mean rating (0–5) of how strongly the concept is experienced by seeing.
-Lynott-2020-Sensorimotor	ENGLISH_FOOT_ACTION_MEAN	mean	sensory modality	foot action strength	ratings	user	en		Foot action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the foot / leg.
-Lynott-2020-Sensorimotor	ENGLISH_HAND_ACTION_MEAN	mean	sensory modality	hand action strength	ratings	user	en		Hand action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the hand / arm.
-Lynott-2020-Sensorimotor	ENGLISH_HEAD_ACTION_MEAN	mean	sensory modality	head action strength	ratings	user	en		Head action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the head excluding mouth.
-Lynott-2020-Sensorimotor	ENGLISH_MOUTH_ACTION_MEAN	mean	sensory modality	mouth action strength	ratings	user	en		Mouth action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the mouth / throat.
-Lynott-2020-Sensorimotor	ENGLISH_TORSO_ACTION_MEAN	mean	sensory modality	torso action strength	ratings	user	en		Torso action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the torso.
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	user	en		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	user	en		Aggregated perceptual strength in all modalities where the influence of weaker modalities is attenuated, calculated as Minkowski distance (with exponent 3) of the 6-dimension vector of perceptual strength from the origin.
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	en		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	user	en		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_STRENGTH_MAX	numeric	sensory modality	maximum action strength	ratings	user	en		Action strength in the dominant effector (i.e., highest strength rating across five action effectors).
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated action strength	ratings	user	en		Aggregated action strength in all effectors where the influence of weaker effectors is attenuated, calculated as Minkowski distance (with exponent 3) of the 5-dimension vector of action strength from the origin.
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_EXCLUSIVITY	percentage	sensory modality	exclusivity action strength	ratings	user	en		Effector exclusivity of the concept; the extent to which a concept is experienced through a single action effector (0–1, typically expressed as %), calculated as the range of action strength values divided by their sum.
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_DOMINANT	linguistic	sensory modality	dominant action strength	ratings	user	en		Action effector through which the concept is experienced most strongly (i.e., with highest action strength rating).
-Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_STRENGTH_MAX	numeric	sensory modality	maximum sensorimotor strength	ratings	user	en		Sensorimotor strength in the dominant dimension (i.e., highest strength rating across 11 sensorimotor dimensions).
-Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated sensorimotor strength	ratings	user	en		Aggregated sensorimotor strength in all dimensions where the influence of weaker dimensions is attenuated, calculated as Minkowski distance (with exponent 3) of the 11-dimension vector of sensorimotor strength from the origin.
-Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_EXCLUSIVITY	percentage	sensory modality	exclusivity sensorimotor strength 	ratings	user	en		Sensorimotor exclusivity of the concept; the extent to which a concept is experienced through a single sensorimotor dimension (0–1, typically expressed as %), calculated as the range of sensorimotor strength values divided by their sum.
-Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_DOMINANT	linguistic	sensory modality	dominant sensorimotor strength	ratings	user	en		Sensorimotor dimension through which the concept is experienced most strongly (i.e., with highest sensorimotor strength rating).
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_KNOWN_PERCENTAGE	percentage	familiarity	perceptual strength	ratings	user	en		Percentage of participants (0–1) in perceptual strength norming who knew the concept well enough to provide valid ratings, calculated as N_known.perceptual divided by List_N.perceptual.
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_KNOWN_PERCENTAGE	percentage	familiarity	action strength	ratings	user	en		Percentage of participants (0–1) in action strength norming who knew the concept well enough to provide valid ratings, calculated as N_known.action divided by List_N.action.
-Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_AOA_MEAN	mean	AoA	perceptual strength	ratings	user	en		Average age of participants in perceptual strength norming who completed the item list featuring the concept (i.e., who were presented with the concept for rating).
-Lynott-2020-Sensorimotor	ENGLISH_ACTION_AOA_MEAN	mean	AoA	action strength	ratings	user	en		Average age of participants in action strength norming who completed the item list featuring the concept (i.e., who were presented with the concept for rating).
-Kapucu-2018-EmotionRatings	TURKISH_VALENCE_MEAN	mean	valence		ratings	user	tr		Mean value for all valid responses on a 9-point Likert SAM scale for valence.
-Kapucu-2018-EmotionRatings	TURKISH_AROUSAL_MEAN	mean	arousal		ratings	user	tr		Mean value for all valid responses on a 9-point Likert SAM scale for arousal.
-Kapucu-2018-EmotionRatings	TURKISH_HAPPINESS_MEAN	mean	happiness		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category happiness.
-Kapucu-2018-EmotionRatings	TURKISH_ANGER_MEAN	mean	anger		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category anger.
-Kapucu-2018-EmotionRatings	TURKISH_SADNESS_MEAN	mean	sadness		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category sadness.
-Kapucu-2018-EmotionRatings	TURKISH_FEAR_MEAN	mean	fear		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category fear.
-Kapucu-2018-EmotionRatings	TURKISH_DISGUST_MEAN	mean	disgust		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category disgust.
-Kapucu-2018-EmotionRatings	TURKISH_CONCRETENESS_MEAN	mean	concreteness		ratings	user	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for concreteness.
-Lewis-2016-499	COMPLEXITY	mean	complexity		ratings	user	en		This is the intuitive complexity of the word on a scale from 1 to 7 based on a survey with 240 valid participants.
-Gampe-2017-48	MEAN_SWISS_GERMAN	mean	familiarity	in Swiss German	ratings	user	de		Mean of whether children understand the word for this concept in Swiss German.
-Gampe-2017-48	MEAN_SECOND_L1	mean	familiarity	in second L1	ratings	user	de		Mean of whether children understand the word for this concept in their other native language.
-Gampe-2017-48	MEAN_TRANSLATIONAL_EQUIV	mean	familiarity	in both L1	ratings	user	de		Mean of whether children understand the word for this concept in both languages.
-Gampe-2017-48	MEAN_CONCEP_VOCAB	mean	familiarity	in any L1	ratings	user	en		Mean of whether children understand the word for this concept in any of their native languages.
-Luniewska-2016-299	AFRIKAANS_AOA	mean	AoA		ratings	user	af		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	CATALAN_AOA	mean	AoA		ratings	user	ca		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	DANISH_AOA	mean	AoA		ratings	user	da		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	DUTCH_AOA	mean	AoA		ratings	user	nl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	ENGLISH_AOA	mean	AoA		ratings	user	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	FINNISH_AOA	mean	AoA		ratings	user	fi		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	GERMAN_AOA	mean	AoA		ratings	user	de		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	GREEK_AOA	mean	AoA		ratings	user	el		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	HEBREW_AOA	mean	AoA		ratings	user	he		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	HUNGARIAN_AOA	mean	AoA		ratings	user	hu		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	ICELANDIC_AOA	mean	AoA		ratings	user	is		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	IRISH_AOA	mean	AoA		ratings	user	ga		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	XHOSA_AOA	mean	AoA		ratings	user	xh		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	ITALIAN_AOA	mean	AoA		ratings	user	it		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	LITHUANIAN_AOA	mean	AoA		ratings	user	lt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	LUXEMBOURGISH_AOA	mean	AoA		ratings	user	lb		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	MALTESE_AOA	mean	AoA		ratings	user	mt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	POLISH_AOA	mean	AoA		ratings	user	pl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	RUSSIAN_AOA	mean	AoA		ratings	user	ru		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	SOUTHAFRICANENGLISH_AOA	mean	AoA	South-African English	ratings	user	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	SERBIAN_AOA	mean	AoA		ratings	user	sr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	SLOVAK_AOA	mean	AoA		ratings	user	sk		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	SPANISH_AOA	mean	AoA		ratings	user	es		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	SWEDISH_AOA	mean	AoA		ratings	user	sv		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2016-299	TURKISH_AOA	mean	AoA		ratings	user	tr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	AFRIKAANS_AOA	mean	AoA		ratings	user	af		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	AMERICANENGLISH_AOA	mean	AoA	American English	ratings	user	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	CATALAN_AOA	mean	AoA		ratings	user	ca		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	CZECH_AOA	mean	AoA		ratings	user	cs		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	DANISH_AOA	mean	AoA		ratings	user	da		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	DUTCH_AOA	mean	AoA		ratings	user	nl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	ENGLISH_AOA	mean	AoA		ratings	user	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	FINNISH_AOA	mean	AoA		ratings	user	fi		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	GAELIC_AOA	mean	AoA		ratings	user	gd		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	GERMAN_AOA	mean	AoA		ratings	user	de		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	GREEK_AOA	mean	AoA		ratings	user	el		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	HEBREW_AOA	mean	AoA		ratings	user	he		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	HUNGARIAN_AOA	mean	AoA		ratings	user	hu		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	ICELANDIC_AOA	mean	AoA		ratings	user	is		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	IRISH_AOA	mean	AoA		ratings	user	ga		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	XHOSA_AOA	mean	AoA		ratings	user	xh		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	ITALIAN_AOA	mean	AoA		ratings	user	it		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	LEBANESEARABIC_AOA	mean	AoA		ratings	user	ar		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	LITHUANIAN_AOA	mean	AoA		ratings	user	lt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	LUXEMBOURGISH_AOA	mean	AoA		ratings	user	lb		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	MALAY_AOA	mean	AoA		ratings	user	ms		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	MALTESE_AOA	mean	AoA		ratings	user	mt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	PERSIAN_AOA	mean	AoA		ratings	user	fa		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	POLISH_AOA	mean	AoA		ratings	user	pl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	RUSSIAN_AOA	mean	AoA		ratings	user	ru		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	SOUTHAFRICANENGLISH_AOA	mean	AoA	South-African English	ratings	user	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	SERBIAN_AOA	mean	AoA		ratings	user	sr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	SLOVAK_AOA	mean	AoA		ratings	user	sk		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	SPANISH_AOA	mean	AoA		ratings	user	es		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	SWEDISH_AOA	mean	AoA		ratings	user	sv		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	TURKISH_AOA	mean	AoA		ratings	user	tr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Luniewska-2019-299	WESTERNARMENIAN_AOA	mean	AoA		ratings	user	hy		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
-Lynott-2013-400	KNOWN_PROPORTION	percentage	familiarity	known	ratings	user	en		Proportion of participants that were familiar with the meaning of the noun (0-100%).
-Lynott-2013-400	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
-Lynott-2013-400	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
-Lynott-2013-400	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
-Lynott-2013-400	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
-Lynott-2013-400	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
+Lynott-2020-Sensorimotor	ENGLISH_AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	en		Auditory strength: mean rating (0–5) of how strongly the concept is experienced by hearing.
+Lynott-2020-Sensorimotor	ENGLISH_GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	en		Gustatory strength: mean rating (0–5) of how strongly the concept is experienced by tasting.
+Lynott-2020-Sensorimotor	ENGLISH_HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	en		Haptic strength: mean rating (0–5) of how strongly the concept is experienced by feeling through touch.
+Lynott-2020-Sensorimotor	ENGLISH_INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	users	en		Interoceptive strength: mean rating (0–5) of how strongly the concept is experienced by sensations inside the body.
+Lynott-2020-Sensorimotor	ENGLISH_OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	en		Olfactory strength: mean rating (0–5) of how strongly the concept is experienced by smelling.
+Lynott-2020-Sensorimotor	ENGLISH_VISUAL_MEAN	mean	sensory modality	visual	ratings	users	en		Visual strength: mean rating (0–5) of how strongly the concept is experienced by seeing.
+Lynott-2020-Sensorimotor	ENGLISH_FOOT_ACTION_MEAN	mean	sensory modality	foot action strength	ratings	users	en		Foot action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the foot / leg.
+Lynott-2020-Sensorimotor	ENGLISH_HAND_ACTION_MEAN	mean	sensory modality	hand action strength	ratings	users	en		Hand action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the hand / arm.
+Lynott-2020-Sensorimotor	ENGLISH_HEAD_ACTION_MEAN	mean	sensory modality	head action strength	ratings	users	en		Head action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the head excluding mouth.
+Lynott-2020-Sensorimotor	ENGLISH_MOUTH_ACTION_MEAN	mean	sensory modality	mouth action strength	ratings	users	en		Mouth action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the mouth / throat.
+Lynott-2020-Sensorimotor	ENGLISH_TORSO_ACTION_MEAN	mean	sensory modality	torso action strength	ratings	users	en		Torso action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the torso.
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	users	en		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	users	en		Aggregated perceptual strength in all modalities where the influence of weaker modalities is attenuated, calculated as Minkowski distance (with exponent 3) of the 6-dimension vector of perceptual strength from the origin.
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	en		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	users	en		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_STRENGTH_MAX	numeric	sensory modality	maximum action strength	ratings	users	en		Action strength in the dominant effector (i.e., highest strength rating across five action effectors).
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated action strength	ratings	users	en		Aggregated action strength in all effectors where the influence of weaker effectors is attenuated, calculated as Minkowski distance (with exponent 3) of the 5-dimension vector of action strength from the origin.
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_EXCLUSIVITY	percentage	sensory modality	exclusivity action strength	ratings	users	en		Effector exclusivity of the concept; the extent to which a concept is experienced through a single action effector (0–1, typically expressed as %), calculated as the range of action strength values divided by their sum.
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_DOMINANT	linguistic	sensory modality	dominant action strength	ratings	users	en		Action effector through which the concept is experienced most strongly (i.e., with highest action strength rating).
+Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_STRENGTH_MAX	numeric	sensory modality	maximum sensorimotor strength	ratings	users	en		Sensorimotor strength in the dominant dimension (i.e., highest strength rating across 11 sensorimotor dimensions).
+Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated sensorimotor strength	ratings	users	en		Aggregated sensorimotor strength in all dimensions where the influence of weaker dimensions is attenuated, calculated as Minkowski distance (with exponent 3) of the 11-dimension vector of sensorimotor strength from the origin.
+Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_EXCLUSIVITY	percentage	sensory modality	exclusivity sensorimotor strength 	ratings	users	en		Sensorimotor exclusivity of the concept; the extent to which a concept is experienced through a single sensorimotor dimension (0–1, typically expressed as %), calculated as the range of sensorimotor strength values divided by their sum.
+Lynott-2020-Sensorimotor	ENGLISH_SENSORIMOTOR_DOMINANT	linguistic	sensory modality	dominant sensorimotor strength	ratings	users	en		Sensorimotor dimension through which the concept is experienced most strongly (i.e., with highest sensorimotor strength rating).
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_KNOWN_PERCENTAGE	percentage	familiarity	perceptual strength	ratings	users	en		Percentage of participants (0–1) in perceptual strength norming who knew the concept well enough to provide valid ratings, calculated as N_known.perceptual divided by List_N.perceptual.
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_KNOWN_PERCENTAGE	percentage	familiarity	action strength	ratings	users	en		Percentage of participants (0–1) in action strength norming who knew the concept well enough to provide valid ratings, calculated as N_known.action divided by List_N.action.
+Lynott-2020-Sensorimotor	ENGLISH_PERCEPTUAL_AOA_MEAN	mean	AoA	perceptual strength	ratings	users	en		Average age of participants in perceptual strength norming who completed the item list featuring the concept (i.e., who were presented with the concept for rating).
+Lynott-2020-Sensorimotor	ENGLISH_ACTION_AOA_MEAN	mean	AoA	action strength	ratings	users	en		Average age of participants in action strength norming who completed the item list featuring the concept (i.e., who were presented with the concept for rating).
+Kapucu-2018-EmotionRatings	TURKISH_VALENCE_MEAN	mean	valence		ratings	users	tr		Mean value for all valid responses on a 9-point Likert SAM scale for valence.
+Kapucu-2018-EmotionRatings	TURKISH_AROUSAL_MEAN	mean	arousal		ratings	users	tr		Mean value for all valid responses on a 9-point Likert SAM scale for arousal.
+Kapucu-2018-EmotionRatings	TURKISH_HAPPINESS_MEAN	mean	happiness		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category happiness.
+Kapucu-2018-EmotionRatings	TURKISH_ANGER_MEAN	mean	anger		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category anger.
+Kapucu-2018-EmotionRatings	TURKISH_SADNESS_MEAN	mean	sadness		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category sadness.
+Kapucu-2018-EmotionRatings	TURKISH_FEAR_MEAN	mean	fear		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category fear.
+Kapucu-2018-EmotionRatings	TURKISH_DISGUST_MEAN	mean	disgust		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for the emotional category disgust.
+Kapucu-2018-EmotionRatings	TURKISH_CONCRETENESS_MEAN	mean	concreteness		ratings	users	tr		Mean value for all valid responses on a scale ranging from 0 (low intensity) to 100 (strong intensity) for concreteness.
+Lewis-2016-499	COMPLEXITY	mean	complexity		ratings	users	en		This is the intuitive complexity of the word on a scale from 1 to 7 based on a survey with 240 valid participants.
+Gampe-2017-48	MEAN_SWISS_GERMAN	mean	familiarity	in Swiss German	ratings	users	de		Mean of whether children understand the word for this concept in Swiss German.
+Gampe-2017-48	MEAN_SECOND_L1	mean	familiarity	in second L1	ratings	users	de		Mean of whether children understand the word for this concept in their other native language.
+Gampe-2017-48	MEAN_TRANSLATIONAL_EQUIV	mean	familiarity	in both L1	ratings	users	de		Mean of whether children understand the word for this concept in both languages.
+Gampe-2017-48	MEAN_CONCEP_VOCAB	mean	familiarity	in any L1	ratings	users	en		Mean of whether children understand the word for this concept in any of their native languages.
+Luniewska-2016-299	AFRIKAANS_AOA	mean	AoA		ratings	users	af		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	CATALAN_AOA	mean	AoA		ratings	users	ca		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	DANISH_AOA	mean	AoA		ratings	users	da		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	DUTCH_AOA	mean	AoA		ratings	users	nl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	ENGLISH_AOA	mean	AoA		ratings	users	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	FINNISH_AOA	mean	AoA		ratings	users	fi		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	GERMAN_AOA	mean	AoA		ratings	users	de		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	GREEK_AOA	mean	AoA		ratings	users	el		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	HEBREW_AOA	mean	AoA		ratings	users	he		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	HUNGARIAN_AOA	mean	AoA		ratings	users	hu		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	ICELANDIC_AOA	mean	AoA		ratings	users	is		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	IRISH_AOA	mean	AoA		ratings	users	ga		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	XHOSA_AOA	mean	AoA		ratings	users	xh		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	ITALIAN_AOA	mean	AoA		ratings	users	it		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	LITHUANIAN_AOA	mean	AoA		ratings	users	lt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	LUXEMBOURGISH_AOA	mean	AoA		ratings	users	lb		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	MALTESE_AOA	mean	AoA		ratings	users	mt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	POLISH_AOA	mean	AoA		ratings	users	pl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	RUSSIAN_AOA	mean	AoA		ratings	users	ru		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	SOUTHAFRICANENGLISH_AOA	mean	AoA	South-African English	ratings	users	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	SERBIAN_AOA	mean	AoA		ratings	users	sr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	SLOVAK_AOA	mean	AoA		ratings	users	sk		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	SPANISH_AOA	mean	AoA		ratings	users	es		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	SWEDISH_AOA	mean	AoA		ratings	users	sv		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2016-299	TURKISH_AOA	mean	AoA		ratings	users	tr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	AFRIKAANS_AOA	mean	AoA		ratings	users	af		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	AMERICANENGLISH_AOA	mean	AoA	American English	ratings	users	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	CATALAN_AOA	mean	AoA		ratings	users	ca		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	CZECH_AOA	mean	AoA		ratings	users	cs		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	DANISH_AOA	mean	AoA		ratings	users	da		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	DUTCH_AOA	mean	AoA		ratings	users	nl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	ENGLISH_AOA	mean	AoA		ratings	users	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	FINNISH_AOA	mean	AoA		ratings	users	fi		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	GAELIC_AOA	mean	AoA		ratings	users	gd		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	GERMAN_AOA	mean	AoA		ratings	users	de		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	GREEK_AOA	mean	AoA		ratings	users	el		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	HEBREW_AOA	mean	AoA		ratings	users	he		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	HUNGARIAN_AOA	mean	AoA		ratings	users	hu		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	ICELANDIC_AOA	mean	AoA		ratings	users	is		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	IRISH_AOA	mean	AoA		ratings	users	ga		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	XHOSA_AOA	mean	AoA		ratings	users	xh		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	ITALIAN_AOA	mean	AoA		ratings	users	it		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	LEBANESEARABIC_AOA	mean	AoA		ratings	users	ar		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	LITHUANIAN_AOA	mean	AoA		ratings	users	lt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	LUXEMBOURGISH_AOA	mean	AoA		ratings	users	lb		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	MALAY_AOA	mean	AoA		ratings	users	ms		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	MALTESE_AOA	mean	AoA		ratings	users	mt		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	PERSIAN_AOA	mean	AoA		ratings	users	fa		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	POLISH_AOA	mean	AoA		ratings	users	pl		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	RUSSIAN_AOA	mean	AoA		ratings	users	ru		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	SOUTHAFRICANENGLISH_AOA	mean	AoA	South-African English	ratings	users	en		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	SERBIAN_AOA	mean	AoA		ratings	users	sr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	SLOVAK_AOA	mean	AoA		ratings	users	sk		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	SPANISH_AOA	mean	AoA		ratings	users	es		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	SWEDISH_AOA	mean	AoA		ratings	users	sv		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	TURKISH_AOA	mean	AoA		ratings	users	tr		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Luniewska-2019-299	WESTERNARMENIAN_AOA	mean	AoA		ratings	users	hy		Native speakers were asked to estimate at which age (between 1 and 18 years) they learnt the respective word.
+Lynott-2013-400	KNOWN_PROPORTION	percentage	familiarity	known	ratings	users	en		Proportion of participants that were familiar with the meaning of the noun (0-100%).
+Lynott-2013-400	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
+Lynott-2013-400	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
+Lynott-2013-400	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
+Lynott-2013-400	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
+Lynott-2013-400	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
 Lynott-2013-400	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	en		Modality through which noun concept is experienced most strongly (i.e., with highest strength rating).
 Lynott-2013-400	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	meta	en		Extent to which noun concept is experienced through a single perceptual modality (0 – 100%), calculated as range of strength values divided by their sum.
 Winter-2016-300	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	en		Modality through which noun concept is experienced most strongly (i.e., with highest strength rating).
-Winter-2016-300	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
-Winter-2016-300	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
-Winter-2016-300	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
-Winter-2016-300	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
-Winter-2016-300	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
+Winter-2016-300	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
+Winter-2016-300	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
+Winter-2016-300	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
+Winter-2016-300	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
+Winter-2016-300	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
 Winter-2016-300	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	norms	meta	en		Extent to which verbs concept is experienced through a single perceptual modality (0 – 100%), calculated as range of strength values divided by their sum.
-Lynott-2009-423	FAMILIARITY	percentage	familiarity		ratings	user	en		The values represent the proportion of participants who believed that they knew the word’s meaning.
-Lynott-2009-423	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
-Lynott-2009-423	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
-Lynott-2009-423	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
-Lynott-2009-423	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
-Lynott-2009-423	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
+Lynott-2009-423	FAMILIARITY	percentage	familiarity		ratings	users	en		The values represent the proportion of participants who believed that they knew the word’s meaning.
+Lynott-2009-423	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
+Lynott-2009-423	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
+Lynott-2009-423	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
+Lynott-2009-423	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
+Lynott-2009-423	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	en		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
 Lynott-2009-423	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	en		Modality through which property is experienced most strongly (i.e., with highest strength rating).
 Lynott-2009-423	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	meta	en		Extent to which property is experienced through a single perceptual modality (0%–100%), calculated as range of strength values divided by their sum.
-Izura-2005-499	SEMANTIC_CATEGORY	linguistic	semantic field		relations	user	es	Hernandez2002	One hundred words were selected per category from the study by [Hernández-Muñoz (2002)](:bib:Hernandez2002), which is an exploration of the common vocabulary shared by the Spanish community of Cuenca. The first 100 words with the highest LA scores in each category were selected for the present study.
-Izura-2005-499	TYPICALITY	mean	typicality		ratings	user	es		Typicality refers to the degree to which a concept (e.g., dog) is representative of a given category (e.g., animals). The participants received an explanation on the meaning of typicality with some examples and were asked to rate each word on a scale ranging from 1 (very atypical example) to 7 (very typical example).
-Izura-2005-499	FAMILIARITY	mean	familiarity		ratings	user	es		The participants were asked to estimate the degree to which they thought about or came into contact with a concept, using a 7-point scale (from 1 less than once a month to 7 many times a day).
-Izura-2005-499	AOA	mean	AoA		ratings	user	es		50 monolingual native Spanish speakers with a mean age of 23 years (range, 18–42) were asked to indicate the age at which they believed they had first learned each word.
-Izura-2005-499	IMAGEABILITY	mean	imageability		ratings	user	es		Ratings were obtained on a scale ranging from 1 (very difficult to arouse a mental image) to 7 (very easy to arouse a mental image).
-Izura-2005-499	LEXICAL_AVAILABILITY	mean	lexical availability		ratings	user	es	Hernandez2002	Lexical availability denotes the readiness with which a word is produced as a member of a given category. The LA values presented here were taken from [Hernández-Muñoz (2002)](:bib:Hernandez2002), who collected written category generation data from 117 Spanish native speakers 17 to 18 years of age.
+Izura-2005-499	SEMANTIC_CATEGORY	linguistic	semantic field		relations	users	es	Hernandez2002	One hundred words were selected per category from the study by [Hernández-Muñoz (2002)](:bib:Hernandez2002), which is an exploration of the common vocabulary shared by the Spanish community of Cuenca. The first 100 words with the highest LA scores in each category were selected for the present study.
+Izura-2005-499	TYPICALITY	mean	typicality		ratings	users	es		Typicality refers to the degree to which a concept (e.g., dog) is representative of a given category (e.g., animals). The participants received an explanation on the meaning of typicality with some examples and were asked to rate each word on a scale ranging from 1 (very atypical example) to 7 (very typical example).
+Izura-2005-499	FAMILIARITY	mean	familiarity		ratings	users	es		The participants were asked to estimate the degree to which they thought about or came into contact with a concept, using a 7-point scale (from 1 less than once a month to 7 many times a day).
+Izura-2005-499	AOA	mean	AoA		ratings	users	es		50 monolingual native Spanish speakers with a mean age of 23 years (range, 18–42) were asked to indicate the age at which they believed they had first learned each word.
+Izura-2005-499	IMAGEABILITY	mean	imageability		ratings	users	es		Ratings were obtained on a scale ranging from 1 (very difficult to arouse a mental image) to 7 (very easy to arouse a mental image).
+Izura-2005-499	LEXICAL_AVAILABILITY	mean	lexical availability		ratings	users	es	Hernandez2002	Lexical availability denotes the readiness with which a word is produced as a member of a given category. The LA values presented here were taken from [Hernández-Muñoz (2002)](:bib:Hernandez2002), who collected written category generation data from 117 Spanish native speakers 17 to 18 years of age.
 Izura-2005-499	FREQUENCY	numeric	frequency		norms	corpus	es	Alameda1995	Frequency values were taken from [Alameda and Cuetos (1995)](:bib:Alameda1995), which is a corpus of written Spanish text comprising 2 million words.
-Schroeder-2012-824	SEMANTIC_CATEGORY	linguistic	semantic field		relations	user	de		A group of 20 participants (15 female, 5 male) took part in the exemplar generation study. Participants were provided with a booklet containing a list of 11 category labels (VEGETABLES, VEHICLES, TOOLS, CLOTHING, FURNITURE, SPORTS, BIRDS, FRUITS, ANIMALS, PROFESSIONS, and MUSICAL INSTRUMENTS1). Each category label was presented on a separate sheet of paper. Participants were asked by written instructions to write down as many examples as they could think of for each semantic category.
-Schroeder-2012-824	TYPICALITY_MEAN	mean	typicality		ratings	user	de		The participants were asked to rate the typicality of the category exemplar on a 7-point scale from 1 (very good example of the category/typical) to 7 (bad example of the category/atypical)
-Schroeder-2012-824	AOA_MEAN	mean	AoA		ratings	user	de		Participants were asked to indicate on a 7-point scale when they thought they had learned the words.
-Schroeder-2012-824	FAMILIARITY_MEAN	mean	familiarity		ratings	user	de		Participants were asked to estimate the degree to which they thought about or came in contact with a concept, using a 5-point scale ranging from 1 (very unfamiliar) to 5 (very familiar).
-Verheyen-2020-1000	AOA_MEAN	mean	AoA		ratings	user	nl		For each word, the participants were asked to enter the age (in years) at which they thought they had learned the word.
-Verheyen-2020-1000	AROUSAL_MEAN	mean	arousal		ratings	user	nl		Participants were asked to indicate the degree to which a word refers to something very passive/calm (1) or very active/arousing (7), and to something very weak/submissive (1) or very strong/dominant (7) for arousal and dominance, respectively.
-Verheyen-2020-1000	CONCRETENESS_MEAN	mean	concreteness		ratings	user	nl		Participants rated each word’s level of abstraction on a 7-point scale ranging from very abstract (1) to very concrete (7).
-Verheyen-2020-1000	DOMINANCE_MEAN	mean	dominance		ratings	user	nl		Participants were asked to indicate the degree to which a word refers to something very passive/calm (1) or very active/arousing (7), and to something very weak/submissive (1) or very strong/dominant (7) for arousal and dominance, respectively.
-Verheyen-2020-1000	FAMILIARITY_MEAN	mean	familiarity		ratings	user	nl		Participants rated how familiar they were with each word in the list by indicating how often they had encountered or used the word. Ratings were performed on 7-point scales.
-Verheyen-2020-1000	IMAGEABILITY_MEAN	mean	imageability		ratings	user	nl		Participants rated each word’s capacity to arouse a mental image by indicating how easily they could form a mental image of the word on a 7-point scale with the ends labeled difficult (1) and easy (7).
-Verheyen-2020-1000	VALENCE_MEAN	mean	valence		ratings	user	nl		Participants rated the valence of each word by indicating on a 7-point scale the extent to which it evoked a very bad (1) or a very good (7) feeling.
-Verheyen-2020-1000	INSTRENGTH	cardinality	network	instrength	relations	user	nl	DeDeyne2019	The in-strength si of a word i reflects the number of links that go into the node representing the word in the word association network and as such provides an indication of the word’s importance in the mental lexicon. The variables in-strength and betweenness were taken from the Small World of Words project (https://smallworldofword.org/), a large-scale study that aims to build a map of the human lexicon in the major languages of the world (including Dutch) using word association data [(De Deyne et al. 2019)](:bib:DeDeyne2019).
-Verheyen-2020-1000	BETWEENNESS	numeric	network	betweenness	relations	user	nl	DeDeyne2019	Betweenness is another indicator of the centrality of a node in the network. It takes the global structure of the word association network more in account than in-strength does in that it captures how often a node is located on the shortest path between other nodes in the network. The variables in-strength and betweenness were taken from the Small World of Words project (https://smallworldofword.org/), a large-scale study that aims to build a map of the human lexicon in the major languages of the world (including Dutch) using word association data [(De Deyne et al. 2019)](:bib:DeDeyne2019).
+Schroeder-2012-824	SEMANTIC_CATEGORY	linguistic	semantic field		relations	users	de		A group of 20 participants (15 female, 5 male) took part in the exemplar generation study. Participants were provided with a booklet containing a list of 11 category labels (VEGETABLES, VEHICLES, TOOLS, CLOTHING, FURNITURE, SPORTS, BIRDS, FRUITS, ANIMALS, PROFESSIONS, and MUSICAL INSTRUMENTS1). Each category label was presented on a separate sheet of paper. Participants were asked by written instructions to write down as many examples as they could think of for each semantic category.
+Schroeder-2012-824	TYPICALITY_MEAN	mean	typicality		ratings	users	de		The participants were asked to rate the typicality of the category exemplar on a 7-point scale from 1 (very good example of the category/typical) to 7 (bad example of the category/atypical)
+Schroeder-2012-824	AOA_MEAN	mean	AoA		ratings	users	de		Participants were asked to indicate on a 7-point scale when they thought they had learned the words.
+Schroeder-2012-824	FAMILIARITY_MEAN	mean	familiarity		ratings	users	de		Participants were asked to estimate the degree to which they thought about or came in contact with a concept, using a 5-point scale ranging from 1 (very unfamiliar) to 5 (very familiar).
+Verheyen-2020-1000	AOA_MEAN	mean	AoA		ratings	users	nl		For each word, the participants were asked to enter the age (in years) at which they thought they had learned the word.
+Verheyen-2020-1000	AROUSAL_MEAN	mean	arousal		ratings	users	nl		Participants were asked to indicate the degree to which a word refers to something very passive/calm (1) or very active/arousing (7), and to something very weak/submissive (1) or very strong/dominant (7) for arousal and dominance, respectively.
+Verheyen-2020-1000	CONCRETENESS_MEAN	mean	concreteness		ratings	users	nl		Participants rated each word’s level of abstraction on a 7-point scale ranging from very abstract (1) to very concrete (7).
+Verheyen-2020-1000	DOMINANCE_MEAN	mean	dominance		ratings	users	nl		Participants were asked to indicate the degree to which a word refers to something very passive/calm (1) or very active/arousing (7), and to something very weak/submissive (1) or very strong/dominant (7) for arousal and dominance, respectively.
+Verheyen-2020-1000	FAMILIARITY_MEAN	mean	familiarity		ratings	users	nl		Participants rated how familiar they were with each word in the list by indicating how often they had encountered or used the word. Ratings were performed on 7-point scales.
+Verheyen-2020-1000	IMAGEABILITY_MEAN	mean	imageability		ratings	users	nl		Participants rated each word’s capacity to arouse a mental image by indicating how easily they could form a mental image of the word on a 7-point scale with the ends labeled difficult (1) and easy (7).
+Verheyen-2020-1000	VALENCE_MEAN	mean	valence		ratings	users	nl		Participants rated the valence of each word by indicating on a 7-point scale the extent to which it evoked a very bad (1) or a very good (7) feeling.
+Verheyen-2020-1000	INSTRENGTH	cardinality	network	instrength	relations	users	nl	DeDeyne2019	The in-strength si of a word i reflects the number of links that go into the node representing the word in the word association network and as such provides an indication of the word’s importance in the mental lexicon. The variables in-strength and betweenness were taken from the Small World of Words project (https://smallworldofword.org/), a large-scale study that aims to build a map of the human lexicon in the major languages of the world (including Dutch) using word association data [(De Deyne et al. 2019)](:bib:DeDeyne2019).
+Verheyen-2020-1000	BETWEENNESS	numeric	network	betweenness	relations	users	nl	DeDeyne2019	Betweenness is another indicator of the centrality of a node in the network. It takes the global structure of the word association network more in account than in-strength does in that it captures how often a node is located on the shortest path between other nodes in the network. The variables in-strength and betweenness were taken from the Small World of Words project (https://smallworldofword.org/), a large-scale study that aims to build a map of the human lexicon in the major languages of the world (including Dutch) using word association data [(De Deyne et al. 2019)](:bib:DeDeyne2019).
 Desrochers-2010-330	WORD_TYPE	linguistic	PoS		relations	meta	es		The list includes deverbal compounds, nouns and verbs.
-Desrochers-2010-330	SUBJECTIVE_FREQ_MEAN	mean	frequency	subjective	norms	user	es		Ratings were collected on a 7-point scale from 102 native speakers of Spanish on the subjective frequency of occurrence of 330 Spanish words.
-DiezAlamo-2018-750	COLOR_MEAN	mean	sensory modality	color	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	MOTION_MEAN	mean	sensory modality	motion	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	GRASP_MEAN	mean	sensory modality	grasp	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	PAIN_MEAN	mean	sensory modality	pain	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	SOUND_MEAN	mean	sensory modality	sound	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	TASTE_MEAN	mean	sensory modality	taste	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-DiezAlamo-2018-750	SMELL_MEAN	mean	sensory modality	smell	ratings	user	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
-Monnier-2014-1031	VALENCE_ALL_MEAN	mean	valence		ratings	user	fr		Mean valence values for all participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
-Monnier-2014-1031	AROUSAL_ALL_MEAN	mean	arousal		ratings	user	fr		Mean arousal values for all participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
-Monnier-2014-1031	VALENCE_MALE_MEAN	mean	valence	male	ratings	user	fr		Mean valence values for male participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
-Monnier-2014-1031	AROUSAL_MALE_MEAN	mean	arousal	male	ratings	user	fr		Mean arousal values for male participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
-Monnier-2014-1031	VALENCE_FEMALE_MEAN	mean	valence	female	ratings	user	fr		Mean valence values for female participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
-Monnier-2014-1031	AROUSAL_FEMALE_MEAN	mean	arousal	female	ratings	user	fr		Mean arousal values for female participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Desrochers-2010-330	SUBJECTIVE_FREQ_MEAN	mean	frequency	subjective	norms	users	es		Ratings were collected on a 7-point scale from 102 native speakers of Spanish on the subjective frequency of occurrence of 330 Spanish words.
+DiezAlamo-2018-750	COLOR_MEAN	mean	sensory modality	color	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	MOTION_MEAN	mean	sensory modality	motion	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	GRASP_MEAN	mean	sensory modality	grasp	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	PAIN_MEAN	mean	sensory modality	pain	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	SOUND_MEAN	mean	sensory modality	sound	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	TASTE_MEAN	mean	sensory modality	taste	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+DiezAlamo-2018-750	SMELL_MEAN	mean	sensory modality	smell	ratings	users	es		Participants were randomly assigned to rate words on a scale from 1 to 8 in only one of the seven dimensions (color, motion, sound, smell, taste, graspability and pain) for the 250 words in a given set.
+Monnier-2014-1031	VALENCE_ALL_MEAN	mean	valence		ratings	users	fr		Mean valence values for all participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Monnier-2014-1031	AROUSAL_ALL_MEAN	mean	arousal		ratings	users	fr		Mean arousal values for all participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Monnier-2014-1031	VALENCE_MALE_MEAN	mean	valence	male	ratings	users	fr		Mean valence values for male participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Monnier-2014-1031	AROUSAL_MALE_MEAN	mean	arousal	male	ratings	users	fr		Mean arousal values for male participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Monnier-2014-1031	VALENCE_FEMALE_MEAN	mean	valence	female	ratings	users	fr		Mean valence values for female participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
+Monnier-2014-1031	AROUSAL_FEMALE_MEAN	mean	arousal	female	ratings	users	fr		Mean arousal values for female participants. The valence and arousal scales from the paperand-pencil version of the 9-point SAM scale (Lang, 1980).
 Maciejewski-2016-100	DEFINITION	semantic	definition		relations	meta	en		Definition of the meanings in the Wordsmyth dictionary.
-Maciejewski-2016-100	SUBJECTIVE_FREQ	mean	frequency	subjective	norms	user	en		Mean subjective frequency ratings of the meanings made by two raters.
+Maciejewski-2016-100	SUBJECTIVE_FREQ	mean	frequency	subjective	norms	users	en		Mean subjective frequency ratings of the meanings made by two raters.
 Maciejewski-2016-100	DOMINANCE_SCORE	numeric	polysemy	dominant	relations	meta	en		Dominance score (B), first calculated for each subject and then averaged across subjects (0 - completely balanced, 1 - completely unbalanced homonym).
 Maciejewski-2016-100	NUMBER_WORD_SENSE_WORDSMYTH	numeric	polysemy	number	relations	meta	en	Parks1998	Number of word senses in the Wordsmyth Online Dictionary [(Parks et al., 1998)](:bib:Parks1998).
-Yao-2017-1100	VALENCE_MEAN	mean	valence		ratings	user	zh		Valence rating on a 9-point Likert scale by 960 university students.
-Yao-2017-1100	AROUSAL_MEAN	mean	arousal		ratings	user	zh		Arousal rating on a 9-point Likert scale 960 university students.
-Yao-2017-1100	CONCRETENESS_MEAN	mean	concreteness		ratings	user	zh		Concreteness rating on a 9-point Likert scale 960 university students.
-Yao-2017-1100	FAMILIARITY_MEAN	mean	familiarity		ratings	user	zh		Familiarity rating on a 9-point Likert scale 960 university students.
-Yao-2017-1100	IMAGEABILITY_MEAN	mean	imageability		ratings	user	zh		Imageability rating on a 9-point Likert scale 960 university students.
-Yao-2017-1100	CONTEXT_AVAILABILITY_MEAN	mean	contect availability		ratings	user	zh		Context availability rating on a 9-point Likert scale 960 university students.
+Yao-2017-1100	VALENCE_MEAN	mean	valence		ratings	users	zh		Valence rating on a 9-point Likert scale by 960 university students.
+Yao-2017-1100	AROUSAL_MEAN	mean	arousal		ratings	users	zh		Arousal rating on a 9-point Likert scale 960 university students.
+Yao-2017-1100	CONCRETENESS_MEAN	mean	concreteness		ratings	users	zh		Concreteness rating on a 9-point Likert scale 960 university students.
+Yao-2017-1100	FAMILIARITY_MEAN	mean	familiarity		ratings	users	zh		Familiarity rating on a 9-point Likert scale 960 university students.
+Yao-2017-1100	IMAGEABILITY_MEAN	mean	imageability		ratings	users	zh		Imageability rating on a 9-point Likert scale 960 university students.
+Yao-2017-1100	CONTEXT_AVAILABILITY_MEAN	mean	contect availability		ratings	users	zh		Context availability rating on a 9-point Likert scale 960 university students.
 Xiao-2012-213	PEN_STROKES	cardinality	strokes		norms	meta	zh		Total number of strokes of the whole-word.
-Xiao-2012-213	ICONICITY	mean	iconicity		ratings	user	zh		40 U.S. adults with no knowledge of Chinese were given an English word or short phrase together with two Chinese characters and were asked which character matched the meaning of the English word.
-Xiao-2012-213	PICTURABILITY	mean	picturability		ratings	user	zh		31 English speaking students were shown the English translations of Chinese characters used in the experiment and had to rate each translation on a 7-point scale to indicate the extent to which the concept could be expressed easily in a simple black-on-white line drawing or diagram.
+Xiao-2012-213	ICONICITY	mean	iconicity		ratings	users	zh		40 U.S. adults with no knowledge of Chinese were given an English word or short phrase together with two Chinese characters and were asked which character matched the meaning of the English word.
+Xiao-2012-213	PICTURABILITY	mean	picturability		ratings	users	zh		31 English speaking students were shown the English translations of Chinese characters used in the experiment and had to rate each translation on a 7-point scale to indicate the extent to which the concept could be expressed easily in a simple black-on-white line drawing or diagram.
 Pagel-2018-200	RATE	numeric	stability	rate	relations	concept lists	en		Stability (rate of lexical change) measured for concepts based on a sample from Indo-European languages.
 Pagel-2007-200	RANK	ordinality	stability	rank	relations	concept lists	en	Dyen1992	Ranks for the 200 basic concepts, which are retrieved from the calculation of evolutionary rates from phylogenetic analyses on the database by Dyen et al (1992).
-Briesemeister-2011-DiscreteEmotions	GERMAN_HAPPINESS_MEAN	mean	happiness		ratings	user	de		Mean value for all valid responses a 5-point scale in the emotional category happiness.
-Briesemeister-2011-DiscreteEmotions	GERMAN_ANGER_MEAN	mean	anger		ratings	user	de		Mean value for all valid responses a 5-point scale in the emotional category anger.
-Briesemeister-2011-DiscreteEmotions	GERMAN_SADNESS_MEAN	mean	sadness		ratings	user	de		Mean value for all valid responses a 5-point scale in the emotional category sadness.
-Briesemeister-2011-DiscreteEmotions	GERMAN_FEAR_MEAN	mean	fear		ratings	user	de		Mean value for all valid responses a 5-point scale in the emotional category fear.
-Briesemeister-2011-DiscreteEmotions	GERMAN_DISGUST_MEAN	mean	disgust		ratings	user	de		Mean value for all valid responses a 5-point scale in the emotional category disgust.
-Briesemeister-2011-DiscreteEmotions	GERMAN_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	user	de		A more conservative classification criterion was applied, assigning words to a specific discrete emotion category only in cases in which the averaged rating in one discrete emotion was more than one standard deviation higher than in any other discrete emotion.
+Briesemeister-2011-DiscreteEmotions	GERMAN_HAPPINESS_MEAN	mean	happiness		ratings	users	de		Mean value for all valid responses a 5-point scale in the emotional category happiness.
+Briesemeister-2011-DiscreteEmotions	GERMAN_ANGER_MEAN	mean	anger		ratings	users	de		Mean value for all valid responses a 5-point scale in the emotional category anger.
+Briesemeister-2011-DiscreteEmotions	GERMAN_SADNESS_MEAN	mean	sadness		ratings	users	de		Mean value for all valid responses a 5-point scale in the emotional category sadness.
+Briesemeister-2011-DiscreteEmotions	GERMAN_FEAR_MEAN	mean	fear		ratings	users	de		Mean value for all valid responses a 5-point scale in the emotional category fear.
+Briesemeister-2011-DiscreteEmotions	GERMAN_DISGUST_MEAN	mean	disgust		ratings	users	de		Mean value for all valid responses a 5-point scale in the emotional category disgust.
+Briesemeister-2011-DiscreteEmotions	GERMAN_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	users	de		A more conservative classification criterion was applied, assigning words to a specific discrete emotion category only in cases in which the averaged rating in one discrete emotion was more than one standard deviation higher than in any other discrete emotion.
 Mandera-2015-Frequency	POLISH_FREQUENCY	tokens	frequency		norms	corpus	pl		This is the number of times the word appears in the corpus of 101 million tokens (449,300 types).
 Mandera-2015-Frequency	POLISH_CD	tokens	contextual diversity		norms	corpus	pl		This  is the number of films (max. 99,635) in which the word appears.
 Mandera-2015-Frequency	POLISH_FREQUENCY_LOG	logarithmic	frequency		norms	corpus	pl		This is a value based on log10(FREQcount+1).
 Mandera-2015-Frequency	POLISH_CD_LOG	logarithmic	contextual diversity		norms	corpus	pl		This value is based on log10(CDcount +1).
-Moors-2013-Ratings	DUTCH_VALENCE_MEAN	mean	valence		ratings	user	nl		Mean valence values for all participants (224 students) on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_AROUSAL_MEAN	mean	arousal		ratings	user	nl		Mean arousal values for all participants (224 students) on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_VALENCE_MALE_MEAN	mean	valence	male	ratings	user	nl		Mean valence values for male participants on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_AROUSAL_MALE_MEAN	mean	arousal	male	ratings	user	nl		Mean arousal values for male participants on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_VALENCE_FEMALE_MEAN	mean	valence	female	ratings	user	nl		Mean valence values for female participants on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_AROUSAL_FEMALE_MEAN	mean	arousal	female	ratings	user	nl		Mean arousal values for female participants on a 7-point Likert scale.
-Moors-2013-Ratings	DUTCH_AOA_MEAN	mean	AoA		ratings	user	nl		Mean age-of-acquisition values for all participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
-Moors-2013-Ratings	DUTCH_AOA_MALE_MEAN	mean	AoA	male	ratings	user	nl		Mean age-of-acquisition values for male participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
-Moors-2013-Ratings	DUTCH_AOA_FEMALE_MEAN	mean	AoA	female	ratings	user	nl		Mean age-of-acquisition values for female participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
+Moors-2013-Ratings	DUTCH_VALENCE_MEAN	mean	valence		ratings	users	nl		Mean valence values for all participants (224 students) on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_AROUSAL_MEAN	mean	arousal		ratings	users	nl		Mean arousal values for all participants (224 students) on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_VALENCE_MALE_MEAN	mean	valence	male	ratings	users	nl		Mean valence values for male participants on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_AROUSAL_MALE_MEAN	mean	arousal	male	ratings	users	nl		Mean arousal values for male participants on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_VALENCE_FEMALE_MEAN	mean	valence	female	ratings	users	nl		Mean valence values for female participants on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_AROUSAL_FEMALE_MEAN	mean	arousal	female	ratings	users	nl		Mean arousal values for female participants on a 7-point Likert scale.
+Moors-2013-Ratings	DUTCH_AOA_MEAN	mean	AoA		ratings	users	nl		Mean age-of-acquisition values for all participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
+Moors-2013-Ratings	DUTCH_AOA_MALE_MEAN	mean	AoA	male	ratings	users	nl		Mean age-of-acquisition values for male participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
+Moors-2013-Ratings	DUTCH_AOA_FEMALE_MEAN	mean	AoA	female	ratings	users	nl		Mean age-of-acquisition values for female participants (224 students). Participants were asked to enter the age at which they thought they had learned the word.
 Wu-2020-CoreVocabulary	TRANSLATION_COUNT	cardinality	core vocabulary	translation count	relations	corpus	en		This value represents the number of languages in which a word occurred. It is the relative coverage of a target concept in 1895 bilingual dictionaries.
-Mohammad-2018-AffectiveRatings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	user	en		Mean value of valence ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest valence and the word with the lowest valence.
-Mohammad-2018-AffectiveRatings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	user	en		Mean value of arousal ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest arousal and the word with the lowest arousal.
-Mohammad-2018-AffectiveRatings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	user	en		Mean value of dominance ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest dominance and the word with the lowest dominance.
-Mohammad-2018-EmotionIntensity	ENGLISH_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	user	en		The most dominant emotion based on pointwise mutual information (PMI) with PMI > 1 in the Hashtag Emotion Corpus [(Mohammad 2012)](:bib:Mohammad2012).
-Mohammad-2018-EmotionIntensity	ENGLISH_EMOTION_INTENSITY	mean	emotion	intensity	ratings	user	en		Mean value of emotion intensity based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word that conveys the highest emotion intensity and the word that conveys the lowest emotion intensity.
-Clark-2004-ImageryFamiliarity	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	en		Mean value of imageability ratings based on a 7-point scale.
-Clark-2004-ImageryFamiliarity	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	user	en		Mean value of familiarity ratings based on a 7-point scale.
+Mohammad-2018-AffectiveRatings	ENGLISH_VALENCE_MEAN	mean	valence		ratings	users	en		Mean value of valence ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest valence and the word with the lowest valence.
+Mohammad-2018-AffectiveRatings	ENGLISH_AROUSAL_MEAN	mean	arousal		ratings	users	en		Mean value of arousal ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest arousal and the word with the lowest arousal.
+Mohammad-2018-AffectiveRatings	ENGLISH_DOMINANCE_MEAN	mean	dominance		ratings	users	en		Mean value of dominance ratings based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word with the highest dominance and the word with the lowest dominance.
+Mohammad-2018-EmotionIntensity	ENGLISH_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	users	en		The most dominant emotion based on pointwise mutual information (PMI) with PMI > 1 in the Hashtag Emotion Corpus [(Mohammad 2012)](:bib:Mohammad2012).
+Mohammad-2018-EmotionIntensity	ENGLISH_EMOTION_INTENSITY	mean	emotion	intensity	ratings	users	en		Mean value of emotion intensity based on best-worst scaling. The participants were presented with four words at a time (4-tuples) and asked to select the word that conveys the highest emotion intensity and the word that conveys the lowest emotion intensity.
+Clark-2004-ImageryFamiliarity	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	en		Mean value of imageability ratings based on a 7-point scale.
+Clark-2004-ImageryFamiliarity	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	users	en		Mean value of familiarity ratings based on a 7-point scale.
 Abdaoui-2017-EmoLex	FRENCH_EMOTION_POLARITY	linguistic	emotion	polarity	norms	corpus	fr		Polarity associated with a word (positive/negative) based on a sentiment analysis of texts.
 Abdaoui-2017-EmoLex	FRENCH_JOY_ASSOCIATION	numeric	joy		norms	corpus	fr		The emotion associated with the word based on a sentiment analysis of texts: 1 (associated) and 0 (not associated).
 Abdaoui-2017-EmoLex	FRENCH_FEAR_ASSOCIATION	numeric	fear		norms	corpus	fr		The emotion associated with the word based on a sentiment analysis of texts: 1 (associated) and 0 (not associated).
@@ -381,9 +381,9 @@ Baroni-2011-200	RANDOM_ADJECTIVE	linguistic	adjective	random	relations	corpus	en
 Baroni-2011-200	RANDOM_NOUN	linguistic	noun	random	relations	corpus	en		This is a list of nouns related to the concept. Random relata were chosen to approximately match the frequency of occurrence of the true relata (frequencies computed on the concatenated WaCkypedia_EN and ukWaC corpora.
 Baroni-2011-200	RANDOM_VERB	linguistic	verb	random	relations	corpus	en		This is a list of verbs related to the concept. Random relata were chosen to approximately match the frequency of occurrence of the true relata (frequencies computed on the concatenated WaCkypedia_EN and ukWaC corpora.
 Matisoff-2015-STEDT	STEDT_ID	linguistic	identifier		relations	corpus	en		This is the identifier of the item in the STEDT database.
-Matisoff-2015-STEDT	SEMANTIC_CATEGORY	linguistic	semantic field		relations	user	en		This is the semantic key (semkey) which is a unique identification string given to each semantic category, with the semkey taking the form of a string x, x.x, x.x.x, or x.x.x.x. The first digit in the semkey indicates the broad semantic category to which it belongs, as described above, where «1» is used for «Body Parts», «2» is used for «Animals (and Animal Verbs)», and so on. Each of the following «x»s in the semkey (x.x, x.x.x, etc.) denotes a more fine-grained semantic categorization; for example, 1.5 is «Limbs, Joints, & Body Measures», 1.5.1 is «Hand, Arm, Wing», and 1.5.1.1 is «Hand».
-Kiss-1973-EAT	WEIGHTED_DEGREE	numeric	associations	weighted degree	relations	user	en		This is the weighted degree we computed from the association data (the sum of all association weights per word).
-Kiss-1973-EAT	DEGREE	numeric	associations	degree	relations	user	en		This is the degree we computed from the association data (the number of association edges per word).
+Matisoff-2015-STEDT	SEMANTIC_CATEGORY	linguistic	semantic field		relations	users	en		This is the semantic key (semkey) which is a unique identification string given to each semantic category, with the semkey taking the form of a string x, x.x, x.x.x, or x.x.x.x. The first digit in the semkey indicates the broad semantic category to which it belongs, as described above, where «1» is used for «Body Parts», «2» is used for «Animals (and Animal Verbs)», and so on. Each of the following «x»s in the semkey (x.x, x.x.x, etc.) denotes a more fine-grained semantic categorization; for example, 1.5 is «Limbs, Joints, & Body Measures», 1.5.1 is «Hand, Arm, Wing», and 1.5.1.1 is «Hand».
+Kiss-1973-EAT	WEIGHTED_DEGREE	numeric	associations	weighted degree	relations	users	en		This is the weighted degree we computed from the association data (the sum of all association weights per word).
+Kiss-1973-EAT	DEGREE	numeric	associations	degree	relations	users	en		This is the degree we computed from the association data (the number of association edges per word).
 Wikidata	WIKIDATA_LABEL	semantic	identifier		relations	corpus	en		This is the label/identifier of the Wikidata item.
 Wikidata	WIKIDATA_DESCRIPTION	semantic	definition		relations	corpus	en		This is the decription of the Wikidata item. It is meant to disambiguate the items.
 Hill-2015-999	SIM_LEX_999	numeric	similarity		relations	corpus	en		The SimLex999 similarity rating. Note that average annotator scores have been (linearly) mapped from the range [0,6] to the range [0,10] to match other datasets such as WordSim-353.
@@ -395,11 +395,11 @@ Hill-2015-999	SIM_ASSOCIATION_333	numeric	associations	binary indicator	relation
 OmegaWiki	OMEGAWIKI_ID	semantic	identifier		relations	corpus	en		This is the identifier of the OmegaWiki item.
 Babelnet	BABELNET_ID	semantic	identifier		relations	corpus	en		This is the identifier of the BabelNet item.
 Babelnet	BABELNET_DEFINITION	semantic	definition		relations	corpus	en		This is the description of the BabelNet item.
-Haspelmath-2009-1460	SEMANTIC_FIELD	linguistic	semantic field		relations	user	en		The semantic field of a given word.
-Haspelmath-2009-1460	AGE_SCORE	numeric	word age		relations	user	en		This gives the average age score of all words corresponding to this meaning.
-Haspelmath-2009-1460	BORROWING_SCORE	percentage	borrowing		relations	user	en		This gives the average borrowed score of all words corresponding to this meaning.
-Haspelmath-2009-1460	SIMPLICITY_SCORE	numeric	word simplicity		relations	user	en		This gives the average simplicity score of all words corresponding to this meaning.
-Haspelmath-2009-1460	RANK	ordinality	stability	rank	relations	user	en		This value indicates the stability of a word and its resistance to borrowing across languages.
+Haspelmath-2009-1460	SEMANTIC_FIELD	linguistic	semantic field		relations	users	en		The semantic field of a given word.
+Haspelmath-2009-1460	AGE_SCORE	numeric	word age		relations	users	en		This gives the average age score of all words corresponding to this meaning.
+Haspelmath-2009-1460	BORROWING_SCORE	percentage	borrowing		relations	users	en		This gives the average borrowed score of all words corresponding to this meaning.
+Haspelmath-2009-1460	SIMPLICITY_SCORE	numeric	word simplicity		relations	users	en		This gives the average simplicity score of all words corresponding to this meaning.
+Haspelmath-2009-1460	RANK	ordinality	stability	rank	relations	users	en		This value indicates the stability of a word and its resistance to borrowing across languages.
 Calude-2011-200	ENGLISH_FREQUENCY	logarithmic	frequency		norms	corpus	en		Log10 frequency of basic words.
 Calude-2011-200	SPANISH_FREQUENCY	logarithmic	frequency		norms	corpus	es		Log10 frequency of basic words.
 Calude-2011-200	RUSSIAN_FREQUENCY	logarithmic	frequency		norms	corpus	ru		Log10 frequency of basic words.
@@ -417,58 +417,58 @@ Calude-2011-200	POLISH_FREQUENCY	logarithmic	frequency		norms	corpus	pl		Log10 f
 Calude-2011-200	BASQUE_FREQUENCY	logarithmic	frequency		norms	corpus	eu		Log10 frequency of basic words.
 Calude-2011-200	MAORI_FREQUENCY	logarithmic	frequency		norms	corpus	mi		Log10 frequency of basic words.
 Calude-2011-200	TOK_PISIN_FREQUENCY	logarithmic	frequency		norms	corpus	tpi		Log10 frequency of basic words.
-Morucci-2019-643	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	it		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
-Morucci-2019-643	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	it		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
-Morucci-2019-643	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	it		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
-Morucci-2019-643	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	it		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
-Morucci-2019-643	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	it		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
+Morucci-2019-643	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	it		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
+Morucci-2019-643	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	it		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
+Morucci-2019-643	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	it		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
+Morucci-2019-643	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	it		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
+Morucci-2019-643	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	it		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
 Morucci-2019-643	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	it		Modality through which adjective concept is experienced most strongly (i.e., with highest strength rating).
 Morucci-2019-643	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	meta	it		Extent to which adjective concept is experienced through a single perceptual modality (0 – 100%), calculated as range of strength values divided by their sum.
-Morucci-2019-643	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	user	it		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
-Morucci-2019-643	PERCEPTUAL_STRENGTH_SUM	sum	sensory modality	perceptual strength	ratings	user	it		The sum of the perceptual scores related to the five sensory modalities.
-Morucci-2019-643	PERCEPTUAL_STRENGTH_ENTROPY	numeric	sensory modality	entropy perceptual strength	ratings	user	it		The variability of the scores across the five sensory modalities.
-Morucci-2019-643	FAMILIARITY_MEAN	mean	familiarity		ratings	user	en		The frequency (1-7) with which a word occurs in everyday life.
-Morucci-2019-643	AOA_MEAN	mean	AoA		ratings	user	en		The age at which a word was learnt. The rating scale goes from one (0–2 years) to seven (13 and older) with intervening points spanning two years. 
-Miklashevsky-2018-506	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	ru		Mean rating (1-7) of how strongly noun concept is experienced by hearing.
-Miklashevsky-2018-506	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	ru		Mean rating (1-7) of how strongly noun concept is experienced by tasting.
-Miklashevsky-2018-506	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	ru		Mean rating (1-7) of how strongly noun concept is experienced by feeling through touch.
-Miklashevsky-2018-506	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	ru		Mean rating (1-7) of how strongly noun concept is experienced by smelling.
-Miklashevsky-2018-506	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	ru		Mean rating (1-7) of how strongly noun concept is experienced by seeing.
-Miklashevsky-2018-506	AOA_MEAN	mean	AoA		ratings	user	ru		The mean of age of acquisition rating. Participants were asked to indicate the age in years from 0 to 15 in which they had acquired the word.
-Miklashevsky-2018-506	SEMANTIC_CATEGORY	linguistic	semantic field		relations	user	ru		The semantic category of the word (16 categories, e.g., action, body part, food).
-Miklashevsky-2018-506	ABSTRACTNESS	linguistic	abstractness		relations	user	ru		The abstractness of the category: Abstract (categories: Action, Intelligence, Sense_Emotion, Sense_Phys) vs. Concrete (all other categories).
+Morucci-2019-643	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	users	it		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
+Morucci-2019-643	PERCEPTUAL_STRENGTH_SUM	sum	sensory modality	perceptual strength	ratings	users	it		The sum of the perceptual scores related to the five sensory modalities.
+Morucci-2019-643	PERCEPTUAL_STRENGTH_ENTROPY	numeric	sensory modality	entropy perceptual strength	ratings	users	it		The variability of the scores across the five sensory modalities.
+Morucci-2019-643	FAMILIARITY_MEAN	mean	familiarity		ratings	users	en		The frequency (1-7) with which a word occurs in everyday life.
+Morucci-2019-643	AOA_MEAN	mean	AoA		ratings	users	en		The age at which a word was learnt. The rating scale goes from one (0–2 years) to seven (13 and older) with intervening points spanning two years. 
+Miklashevsky-2018-506	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	ru		Mean rating (1-7) of how strongly noun concept is experienced by hearing.
+Miklashevsky-2018-506	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	ru		Mean rating (1-7) of how strongly noun concept is experienced by tasting.
+Miklashevsky-2018-506	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	ru		Mean rating (1-7) of how strongly noun concept is experienced by feeling through touch.
+Miklashevsky-2018-506	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	ru		Mean rating (1-7) of how strongly noun concept is experienced by smelling.
+Miklashevsky-2018-506	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	ru		Mean rating (1-7) of how strongly noun concept is experienced by seeing.
+Miklashevsky-2018-506	AOA_MEAN	mean	AoA		ratings	users	ru		The mean of age of acquisition rating. Participants were asked to indicate the age in years from 0 to 15 in which they had acquired the word.
+Miklashevsky-2018-506	SEMANTIC_CATEGORY	linguistic	semantic field		relations	users	ru		The semantic category of the word (16 categories, e.g., action, body part, food).
+Miklashevsky-2018-506	ABSTRACTNESS	linguistic	abstractness		relations	users	ru		The abstractness of the category: Abstract (categories: Action, Intelligence, Sense_Emotion, Sense_Phys) vs. Concrete (all other categories).
 Miklashevsky-2018-506	OBJECTIVE_WORD_FREQUENCY	logarithmic	frequency		norms	corpus	ru	Ljashevskaja2009	The decimal logarithm of objective word frequency (based on [Ljashevskaja and Sharov 2009](:bib:Ljashevskaja2009)).
-Miklashevsky-2018-506	IMAGEABILITY_MEAN	mean	imageability		ratings	user	ru		Imageability estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
-Miklashevsky-2018-506	MANIPULABILITY_MEAN	mean	sensory modality	manipulability	ratings	user	ru		Manipulability estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
-Miklashevsky-2018-506	SPATIAL_LOCALIZATION_MEAN	mean	spatial localization		ratings	user	ru		Spatial localization estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
-Miklashevsky-2018-506	SUBJECTIVE_FREQ_MEAN	mean	frequency	subjective	norms	user	ru		 Subjective frequency estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
-Chen-2019-171	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
-Chen-2019-171	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
-Chen-2019-171	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
-Chen-2019-171	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
-Chen-2019-171	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
-Chen-2019-171	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
+Miklashevsky-2018-506	IMAGEABILITY_MEAN	mean	imageability		ratings	users	ru		Imageability estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
+Miklashevsky-2018-506	MANIPULABILITY_MEAN	mean	sensory modality	manipulability	ratings	users	ru		Manipulability estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
+Miklashevsky-2018-506	SPATIAL_LOCALIZATION_MEAN	mean	spatial localization		ratings	users	ru		Spatial localization estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
+Miklashevsky-2018-506	SUBJECTIVE_FREQ_MEAN	mean	frequency	subjective	norms	users	ru		 Subjective frequency estimates were based on a 7-point rating scale (1—the lowest; 7—the highest).
+Chen-2019-171	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
+Chen-2019-171	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
+Chen-2019-171	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
+Chen-2019-171	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
+Chen-2019-171	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
+Chen-2019-171	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
 Chen-2019-171	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	zh		Modality through which adjective concept is experienced most strongly (i.e., with highest strength rating).
-Chen-2019-61	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
-Chen-2019-61	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
-Chen-2019-61	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
-Chen-2019-61	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
-Chen-2019-61	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	zh		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
+Chen-2019-61	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by hearing.
+Chen-2019-61	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by tasting.
+Chen-2019-61	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by feeling through touch.
+Chen-2019-61	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by smelling.
+Chen-2019-61	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	zh		Mean rating (0-5) of how strongly adjective concept is experienced by seeing.
 Chen-2019-61	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	zh		Modality through which adjective concept is experienced most strongly (i.e., with highest strength rating).
-Chen-2019-61	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
-Speed-2017-485	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	nl		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
-Speed-2017-485	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	nl		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
-Speed-2017-485	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	nl		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
-Speed-2017-485	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	nl		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
-Speed-2017-485	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	nl		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
+Chen-2019-61	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
+Speed-2017-485	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	nl		Mean rating (0-5) of how strongly noun concept is experienced by hearing.
+Speed-2017-485	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	nl		Mean rating (0-5) of how strongly noun concept is experienced by tasting.
+Speed-2017-485	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	nl		Mean rating (0-5) of how strongly noun concept is experienced by feeling through touch.
+Speed-2017-485	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	nl		Mean rating (0-5) of how strongly noun concept is experienced by smelling.
+Speed-2017-485	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	nl		Mean rating (0-5) of how strongly noun concept is experienced by seeing.
 Speed-2017-485	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	meta	nl		Modality through which adjective concept is experienced most strongly (i.e., with highest strength rating).
-Speed-2017-485	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	nl		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
-Speed-2017-485	AROUSAL_MEAN	mean	arousal		ratings	user	nl		This is the mean of the arousal ratings for each word on a 7-point scale (0-7).
-Speed-2017-485	DOMINANCE_MEAN	mean	dominance		ratings	user	nl		This is the mean of the dominance ratings for each word on a 7-point scale (0-7).
-Speed-2017-485	VALENCE_MEAN	mean	valence		ratings	user	nl		This is the mean of the valence ratings for each word on a 7-point scale (0-7).
+Speed-2017-485	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	nl		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
+Speed-2017-485	AROUSAL_MEAN	mean	arousal		ratings	users	nl		This is the mean of the arousal ratings for each word on a 7-point scale (0-7).
+Speed-2017-485	DOMINANCE_MEAN	mean	dominance		ratings	users	nl		This is the mean of the dominance ratings for each word on a 7-point scale (0-7).
+Speed-2017-485	VALENCE_MEAN	mean	valence		ratings	users	nl		This is the mean of the valence ratings for each word on a 7-point scale (0-7).
 Crepaldi-2015-Frequency	ITALIAN_FREQUENCY	tokens	frequency		norms	corpus	it		This is the number of times the word appears in the corpus (number of words in the corpus not specified).
 Crepaldi-2015-Frequency	ITALIAN_CD	tokens	contextual diversity		norms	corpus	it		This is the number of films in which the word appears.
-Johansson-2020-344	SOUND_SYMBOLIC	numeric	sound symbolism		norms	user	en		The value indicates if an item is potentially sound symbolic or not, where «1» indicates the concepts with sound-meaning associations whereas «0» means the lack thereof. The analysis of sound symbolic patterns is based on data across 245 language families.
+Johansson-2020-344	SOUND_SYMBOLIC	numeric	sound symbolism		norms	users	en		The value indicates if an item is potentially sound symbolic or not, where «1» indicates the concepts with sound-meaning associations whereas «0» means the lack thereof. The analysis of sound symbolic patterns is based on data across 245 language families.
 VanHeuven-2014-Frequency	ENGLISH_FREQUENCY	tokens	frequency		norms	corpus	en		This is the number of times the word appears in the corpus of 201.3 million words (160,022 word types) from 45,099 BBC broadcasts.
 VanHeuven-2014-Frequency	ENGLISH_FREQUENCY_CBEEBIES	tokens	frequency	Cbeebies	norms	corpus	en		This is the number of times the word appears in the Cbeebies corpus (a channel for pre-school children, age 0-6).
 VanHeuven-2014-Frequency	ENGLISH_FREQUENCY_CBBC	tokens	frequency	CBBC	norms	corpus	en		This is the number of times the word appears in the CBBC corpus (a channel for primary school children, age 6-12).
@@ -486,27 +486,27 @@ Vergallito-2020-1121	ACCURACY_NAMING_MEAN	percentage	naming	accuracy	ratings	use
 Vergallito-2020-1121	NAMING_RT_MEAN	mean	reaction time	naming	ratings	users	it		This is the mean raw reaction times in the naming task.
 Vergallito-2020-1121	LD_RT_ZSCORE	standardized	lexical decision	reaction time	ratings	users	it		This is the reaction times scaled for participant and session, lexical decision task.
 Vergallito-2020-1121	NAMING_RT_ZSCORE	standardized	reaction time	naming	ratings	users	it		This is the reaction times scaled for participant and session, naming task.
-Vergallito-2020-1121	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	it		This is the mean rating in the auditory modality on a scale from 0 (not at all) to 5 (greatly).
-Vergallito-2020-1121	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	it		This is the mean rating in the gustatory modality on a scale from 0 (not at all) to 5 (greatly).
-Vergallito-2020-1121	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	it		This is the mean rating in the haptic modality on a scale from 0 (not at all) to 5 (greatly).
-Vergallito-2020-1121	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	it		This is the mean rating in the olfactory modality on a scale from 0 (not at all) to 5 (greatly).
-Vergallito-2020-1121	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	it		This is the mean rating in the visual modality on a scale from 0 (not at all) to 5 (greatly).
-Vergallito-2020-1121	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	user	it		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
-Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	user	it		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
-Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MIN	numeric	sensory modality	minimum perceptual strength	ratings	user	it		Perceptual strength in the dominant modality (i.e., lowest strength rating across six perceptual modalities).
-Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MEAN	mean	sensory modality	 perceptual strength	ratings	user	it		This is the mean Pperceptual strength in the dominant modality.
-Vergallito-2020-1121	VECTOR_MAGNITUDE	magnitude	sensory modality	 vector	ratings	user	it		This is the length of the vector, including the scores for the five perceptual modalities.
+Vergallito-2020-1121	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	it		This is the mean rating in the auditory modality on a scale from 0 (not at all) to 5 (greatly).
+Vergallito-2020-1121	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	it		This is the mean rating in the gustatory modality on a scale from 0 (not at all) to 5 (greatly).
+Vergallito-2020-1121	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	it		This is the mean rating in the haptic modality on a scale from 0 (not at all) to 5 (greatly).
+Vergallito-2020-1121	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	it		This is the mean rating in the olfactory modality on a scale from 0 (not at all) to 5 (greatly).
+Vergallito-2020-1121	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	it		This is the mean rating in the visual modality on a scale from 0 (not at all) to 5 (greatly).
+Vergallito-2020-1121	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	users	it		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
+Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	users	it		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
+Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MIN	numeric	sensory modality	minimum perceptual strength	ratings	users	it		Perceptual strength in the dominant modality (i.e., lowest strength rating across six perceptual modalities).
+Vergallito-2020-1121	PERCEPTUAL_STRENGTH_MEAN	mean	sensory modality	 perceptual strength	ratings	users	it		This is the mean Pperceptual strength in the dominant modality.
+Vergallito-2020-1121	VECTOR_MAGNITUDE	magnitude	sensory modality	 vector	ratings	users	it		This is the length of the vector, including the scores for the five perceptual modalities.
 Blomberg-2020-160	SEMANTIC_CATEGORY	linguistic	semantic field		relations		sv		The semantic category of the word (categories: specific, general, emotional, abstract).
-Medler-2005-Perceptual	ENGLISH_SOUND_MEAN	mean	sensory modality	sound	ratings	user	en		This is the mean rating in the sound modality on a scale from 0 (NO sound associated) to 6 (DOES VERY MUCH have sound associated).
-Medler-2005-Perceptual	ENGLISH_COLOR_MEAN	mean	sensory modality	color	ratings	user	en		This is the mean rating in the color modality on a scale from 0 (NO color associated) to 6 (DOES VERY MUCH have color associated).
-Medler-2005-Perceptual	ENGLISH_MANIPULATION_MEAN	mean	sensory modality	manipulability	ratings	user	en		This is the mean rating in the manipulation modality on a scale from 0 (NO manipulation associated) to 6 (DOES VERY MUCH have manipulation associated).
-Medler-2005-Perceptual	ENGLISH_MOTION_MEAN	mean	sensory modality	motion	ratings	user	en		This is the mean rating in the motion modality on a scale from 0 (NO motion associated) to 6 (DOES VERY MUCH have motion associated).
-Medler-2005-Perceptual	ENGLISH_EMOTION_MEAN	mean	sensory modality	emotion association	ratings	user	en		This is the mean rating in the emotion modality on a scale from -6 (VERY STRONG NEGATIVE emotion associated) to 6 (VERY STRONG POSITIVE emotion associated).
-Gilhooly-1980-Ratings	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	user	en		Mean value of imageability ratings based on a 7-point scale.
-Gilhooly-1980-Ratings	ENGLISH_AOA_MEAN	mean	AoA		ratings	user	en		Mean value of age-of-acquisition ratings based on a 7-point scale.
-Gilhooly-1980-Ratings	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	user	en		Mean value of familiarity ratings based on a 7-point scale.
-Gilhooly-1980-Ratings	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	user	en		Mean value of concreteness ratings based on a 7-point scale.
-Gilhooly-1980-Ratings	ENGLISH_MEANING_UNCERTAINTY	numeric	ambiguity	degree	ratings	user	en		An information theory measure of the average uncertainty of which meaning would be dominant was derived from the response data for each word. This measure of meaning uncertainty (U) provides a numerical index of degree of ambiguity.
+Medler-2005-Perceptual	ENGLISH_SOUND_MEAN	mean	sensory modality	sound	ratings	users	en		This is the mean rating in the sound modality on a scale from 0 (NO sound associated) to 6 (DOES VERY MUCH have sound associated).
+Medler-2005-Perceptual	ENGLISH_COLOR_MEAN	mean	sensory modality	color	ratings	users	en		This is the mean rating in the color modality on a scale from 0 (NO color associated) to 6 (DOES VERY MUCH have color associated).
+Medler-2005-Perceptual	ENGLISH_MANIPULATION_MEAN	mean	sensory modality	manipulability	ratings	users	en		This is the mean rating in the manipulation modality on a scale from 0 (NO manipulation associated) to 6 (DOES VERY MUCH have manipulation associated).
+Medler-2005-Perceptual	ENGLISH_MOTION_MEAN	mean	sensory modality	motion	ratings	users	en		This is the mean rating in the motion modality on a scale from 0 (NO motion associated) to 6 (DOES VERY MUCH have motion associated).
+Medler-2005-Perceptual	ENGLISH_EMOTION_MEAN	mean	sensory modality	emotion association	ratings	users	en		This is the mean rating in the emotion modality on a scale from -6 (VERY STRONG NEGATIVE emotion associated) to 6 (VERY STRONG POSITIVE emotion associated).
+Gilhooly-1980-Ratings	ENGLISH_IMAGEABILITY_MEAN	mean	imageability		ratings	users	en		Mean value of imageability ratings based on a 7-point scale.
+Gilhooly-1980-Ratings	ENGLISH_AOA_MEAN	mean	AoA		ratings	users	en		Mean value of age-of-acquisition ratings based on a 7-point scale.
+Gilhooly-1980-Ratings	ENGLISH_FAMILIARITY_MEAN	mean	familiarity		ratings	users	en		Mean value of familiarity ratings based on a 7-point scale.
+Gilhooly-1980-Ratings	ENGLISH_CONCRETENESS_MEAN	mean	concreteness		ratings	users	en		Mean value of concreteness ratings based on a 7-point scale.
+Gilhooly-1980-Ratings	ENGLISH_MEANING_UNCERTAINTY	numeric	ambiguity	degree	ratings	users	en		An information theory measure of the average uncertainty of which meaning would be dominant was derived from the response data for each word. This measure of meaning uncertainty (U) provides a numerical index of degree of ambiguity.
 Gilhooly-1980-Ratings	ENGLISH_FREQUENCY	tokens	frequency		ratings	corpus	en	Thorndike1944	Frequencies of English words based on the Thorndike–Lorge list of 30,000 words ([Thorndike and Lorge 1944](:bib:Thorndike1944)).
 Scheible-2014-1755	SCORED_RELATIONS	linguistic	semantic class		relations	users	de		The targeted relation between a word pair: antonym (ANT), hyponym (HYP), synonym (SYN), scored as the mean of similarity judgments on a 5-point scale.
 Lapesa-2014-772	SCORED_RELATIONS	object	polysemy	degree	relations	users	en		Scored polysemy relations.
@@ -549,71 +549,71 @@ Goz-2017-600	AOA_MEAN_OLD	mean	AoA	old	ratings	users	tr		This value includes the
 Goz-2017-600	MEAN_IMAGEABILITY	mean	imageability		ratings	users	tr	Tekcan2005	Imageability estimates were based on a scale from 1 to 7.
 Goz-2017-600	MEAN_CONCRETENESS	mean	concreteness		ratings	users	tr	Tekcan2005	Concreteness estimates were based on a scale from 1 to 7.
 Goz-2017-600	FREQUENCY	tokens	frequency		norms	corpus	tr	Goz2003	This value is taken from a frequency dictionary of written Turkish based on 1,016,000 words obtained from a variety of written sources, published between 1995 and 2000.
-Speed-2021-Sensorimotor	DUTCH_AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by hearing.
-Speed-2021-Sensorimotor	DUTCH_GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by tasting.
-Speed-2021-Sensorimotor	DUTCH_HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by feeling through touch.
-Speed-2021-Sensorimotor	DUTCH_INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by sensations inside the body.
-Speed-2021-Sensorimotor	DUTCH_OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by smelling.
-Speed-2021-Sensorimotor	DUTCH_VISUAL_MEAN	mean	sensory modality	visual	ratings	user	nl		Mean rating (0-5) of how strongly the concept is experienced by seeing.
-Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	user	nl		Modality in which the concept is experienced the strongest  .
-Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	nl		The degree to which a concept can be mapped onto one single perceptual modality. Calculated by dividing the range of ratings by the sum.
-Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	user	nl		Maximum perceptual strength.
-Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_MEAN	mean	sensory modality	perceptual strength	ratings	user	nl		Average perceptual strength.
-Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	user	nl		Sensory strength across modalities with the effect of weaker modalities attenuated.
-Chedid-2019-Familiarity	FRENCH_RT_MEAN	mean	lexical decision	reaction time	norms	user	fr		Mean of the response time for French nouns.
-Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MEAN	mean	familiarity		ratings	user	fr		Mean of the conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
-Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MAX	numeric	familiarity	maximum	ratings	user	fr		The maximum of conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
-Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MIN	numeric	familiarity	minimum	ratings	user	fr		The minimum of conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
-Zhong-2022-664	VISUAL_MEAN	mean	sensory modality	visual	ratings	user	zh		Visual strength: mean rating (0–5) of how strongly the concept is experienced by seeing.
-Zhong-2022-664	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	user	zh		Auditory strength: mean rating (0–5) of how strongly the concept is experienced by hearing.
-Zhong-2022-664	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	user	zh		Gustatory strength: mean rating (0–5) of how strongly the concept is experienced by tasting.
-Zhong-2022-664	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	user	zh		Olfactory strength: mean rating (0–5) of how strongly the concept is experienced by smelling.
-Zhong-2022-664	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	user	zh		Haptic strength: mean rating (0–5) of how strongly the concept is experienced by feeling through touch.
-Zhong-2022-664	INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	user	zh		Interoceptive strength: mean rating (0–5) of how strongly the concept is experienced by sensations inside the body.
-Zhong-2022-664	PERCEPTUAL_MEAN	mean	sensory modality	perceptual strength	ratings	user	zh		This value represents the mean perceptual strength.
-Zhong-2022-664	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	user	zh		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
-Zhong-2022-664	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	user	zh		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
-Zhong-2022-664	PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	user	zh		Aggregated perceptual strength in all modalities where the influence of weaker modalities is attenuated, calculated as Minkowski distance (with exponent 3) of the 6-dimension vector of perceptual strength from the origin.
-Zhong-2022-664	PERCEPTUAL_STRENGTH_SUM	sum	sensory modality	perceptual strength	ratings	user	zh		This value represents the summarized perceptual strength.
-Zhong-2022-664	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	user	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
-Zhong-2022-664	FOOT_ACTION_MEAN	mean	sensory modality	foot action strength	ratings	user	zh		Foot action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the foot / leg.
-Zhong-2022-664	HAND_ACTION_MEAN	mean	sensory modality	hand action strength	ratings	user	zh		Hand action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the hand / arm.
-Zhong-2022-664	MOUTH_ACTION_MEAN	mean	sensory modality	mouth action strength	ratings	user	zh		Mouth action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the mouth / throat.
-Zhong-2022-664	HEAD_ACTION_MEAN	mean	sensory modality	head action strength	ratings	user	zh		Head action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the head excluding mouth.
-Zhong-2022-664	TORSO_ACTION_MEAN	mean	sensory modality	torso action strength	ratings	user	zh		Torso action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the torso.
-Zhong-2022-664	ACTION_STRENGTH_MEAN	mean	sensory modality	action strength	ratings	user	zh		This value represents the mean action effector strength.
-Zhong-2022-664	ACTION_STRENGTH_SUM	sum	sensory modality	action strength	ratings	user	zh		This value represents the summarized action effector strength.
-Zhong-2022-664	ACTION_STRENGTH_MAX	numeric	sensory modality	maximum action strength	ratings	user	zh		Action strength in the dominant effector (i.e., highest strength rating across five action effectors).
-Zhong-2022-664	ACTION_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated action strength	ratings	user	zh		Aggregated action strength in all effectors where the influence of weaker effectors is attenuated, calculated as Minkowski distance (with exponent 3) of the 5-dimension vector of action strength from the origin.
-Zhong-2022-664	ACTION_EXCLUSIVITY	percentage	sensory modality	exclusivity action strength	ratings	user	zh		Effector exclusivity of the concept; the extent to which a concept is experienced through a single action effector (0–1, typically expressed as %), calculated as the range of action strength values divided by their sum.
-Zhong-2022-664	ACTION_DOMINANT	linguistic	sensory modality	dominant action strength	ratings	user	zh		Action effector through which the concept is experienced most strongly (i.e., with highest action strength rating).
-Zhong-2022-664	SENSORIMOTOR_STRENGTH_MAX	numeric	sensory modality	maximum sensorimotor strength	ratings	user	zh		Sensorimotor strength in the dominant dimension (i.e., highest strength rating across 11 sensorimotor dimensions).
-Zhong-2022-664	SENSORIMOTOR_DOMINANT	linguistic	sensory modality	dominant sensorimotor strength	ratings	user	zh		Sensorimotor dimension through which the concept is experienced most strongly (i.e., with highest sensorimotor strength rating).
-Zhong-2022-664	SENSORIMOTOR_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated sensorimotor strength	ratings	user	zh		Aggregated sensorimotor strength in all dimensions where the influence of weaker dimensions is attenuated, calculated as Minkowski distance (with exponent 3) of the 11-dimension vector of sensorimotor strength from the origin.
-Zhong-2022-664	SENSORIMOTOR_STRENGTH_SUM	sum	sensory modality	sensorimotor strength	ratings	user	zh		This value represents the summarized sensorimotor strength in all dimensions.
-Zhong-2022-664	SENSORIMOTOR_EXCLUSIVITY	percentage	sensory modality	exclusivity sensorimotor strength	ratings	user	zh		Sensorimotor exclusivity of the concept; the extent to which a concept is experienced through a single sensorimotor dimension (0–1, typically expressed as %), calculated as the range of sensorimotor strength values divided by their sum.
-Zhong-2022-664	CONCRETE_ABSTRACT	linguistic	concrete/abstract		ratings	user	zh		This value represents the categorical distinction of whether the word is abstract or concrete.
-Jackson-2019-24	VALENCE	mean	valence		ratings	user	en		Valence ratings for emotion concepts based on a 10-point Likert scale.
-Jackson-2019-24	ACTIVATION	mean	arousal		ratings	user	en		Arousal ratings for emotion concepts based on a 10-point Likert scale.
-Jackson-2019-24	DOMINANCE	mean	dominance		ratings	user	en		Dominance ratings for emotion concepts based on a 10-point Likert scale.
-Jackson-2019-24	CERTAINTY	mean	certainty		ratings	user	en		Certainty ratings for emotion concepts based on a 10-point Likert scale.
-Jackson-2019-24	APPROACH_AVOIDANCE	mean	approach avoidance		ratings	user	en		Approach avoidance ratings for emotion concepts based on a 10-point Likert scale.
-Jackson-2019-24	SOCIALITY	mean	sociality		ratings	user	en		Sociality ratings for emotion concepts based on a 10-point Likert scale.
-Wang-2021-90	ISC_BRAIN_OBJNOBJ	numeric	intersubject consistency		norms	user	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask defined by contrasting object words with nonobject words.
-Wang-2021-90	ISC_BRAIN_WORDNEUROSYNTH	numeric	intersubject consistency	term word	norms	user	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask associated with the term word in the Neurosynth platform.
-Wang-2021-90	ISC_BRAIN_OBJEMONOBJNENOBJ	numeric	intersubject consistency	object contrast	norms	user	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask defined by contrasting objects versus emotional nonobjects versus nonemotional nonobjects.
-Wang-2021-90	ISC_BRAIN_OBJNOBJ_LEAVE2_TOP300	numeric	intersubject consistency	individual-subject	norms	user	zh		Intersubject consistency (ISC) values from brain data, calculated from the individual-subject brain mask defined by contrasting object words with nonobject words; there were 300 voxels in each subject mask.
-Wang-2021-90	ISC_BEHAVIORAL	numeric	intersubject consistency	behavioral	norms	user	zh		Intersubject consistency (ISC) values from behavioral data.
-Wang-2021-90	SER_ZSCORE	standardized	sensory experience		ratings	user	zh		The averge of z-scores of language and sensory-experience rating means.
-Wang-2021-90	LANGUAGE_DESCRIPTIVENESS_MEAN	mean	descriptiveness		ratings	user	zh		The rating mean of language descriptiveness on a 7-point scale.
-Wang-2021-90	SER_MEAN	mean	sensory experience		ratings	user	zh		The rating mean of sensory experience on a 7-point scale.
-Wang-2021-90	NAVIGATION_MEAN	mean	navigation		ratings	user	zh		The rating mean of navigation on a 7-point scale.
-Wang-2021-90	MANIPULATION_MEAN	mean	sensory modality	manipulability	ratings	user	zh		The rating mean of manipulation on a 7-point scale.
-Wang-2021-90	STRESS_ACTION_MEAN	mean	action	stress-related	ratings	user	zh		The rating mean of stress-related action on a 7-point scale.
-Wang-2021-90	AROUSAL_MEAN	mean	arousal		ratings	user	zh		The rating mean of arousal on a 7-point scale.
-Wang-2021-90	VALENCE_MEAN	mean	valence		ratings	user	zh		The rating mean of emotional valence on a 7-point scale.
+Speed-2021-Sensorimotor	DUTCH_AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by hearing.
+Speed-2021-Sensorimotor	DUTCH_GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by tasting.
+Speed-2021-Sensorimotor	DUTCH_HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by feeling through touch.
+Speed-2021-Sensorimotor	DUTCH_INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by sensations inside the body.
+Speed-2021-Sensorimotor	DUTCH_OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by smelling.
+Speed-2021-Sensorimotor	DUTCH_VISUAL_MEAN	mean	sensory modality	visual	ratings	users	nl		Mean rating (0-5) of how strongly the concept is experienced by seeing.
+Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	users	nl		Modality in which the concept is experienced the strongest  .
+Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	nl		The degree to which a concept can be mapped onto one single perceptual modality. Calculated by dividing the range of ratings by the sum.
+Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	users	nl		Maximum perceptual strength.
+Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_MEAN	mean	sensory modality	perceptual strength	ratings	users	nl		Average perceptual strength.
+Speed-2021-Sensorimotor	DUTCH_PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	users	nl		Sensory strength across modalities with the effect of weaker modalities attenuated.
+Chedid-2019-Familiarity	FRENCH_RT_MEAN	mean	lexical decision	reaction time	norms	users	fr		Mean of the response time for French nouns.
+Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MEAN	mean	familiarity		ratings	users	fr		Mean of the conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
+Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MAX	numeric	familiarity	maximum	ratings	users	fr		The maximum of conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
+Chedid-2019-Familiarity	FRENCH_FAMILIARITY_MIN	numeric	familiarity	minimum	ratings	users	fr		The minimum of conceptual familiarity ratings based on a scale from 0 (extreme left) to 100 (extreme right).
+Zhong-2022-664	VISUAL_MEAN	mean	sensory modality	visual	ratings	users	zh		Visual strength: mean rating (0–5) of how strongly the concept is experienced by seeing.
+Zhong-2022-664	AUDITORY_MEAN	mean	sensory modality	auditory	ratings	users	zh		Auditory strength: mean rating (0–5) of how strongly the concept is experienced by hearing.
+Zhong-2022-664	GUSTATORY_MEAN	mean	sensory modality	gustatory	ratings	users	zh		Gustatory strength: mean rating (0–5) of how strongly the concept is experienced by tasting.
+Zhong-2022-664	OLFACTORY_MEAN	mean	sensory modality	olfactory	ratings	users	zh		Olfactory strength: mean rating (0–5) of how strongly the concept is experienced by smelling.
+Zhong-2022-664	HAPTIC_MEAN	mean	sensory modality	haptic	ratings	users	zh		Haptic strength: mean rating (0–5) of how strongly the concept is experienced by feeling through touch.
+Zhong-2022-664	INTEROCEPTIVE_MEAN	mean	sensory modality	interoceptive	ratings	users	zh		Interoceptive strength: mean rating (0–5) of how strongly the concept is experienced by sensations inside the body.
+Zhong-2022-664	PERCEPTUAL_MEAN	mean	sensory modality	perceptual strength	ratings	users	zh		This value represents the mean perceptual strength.
+Zhong-2022-664	PERCEPTUAL_DOMINANT	linguistic	sensory modality	dominant perceptual strength	ratings	users	zh		Perceptual modality through which the concept is experienced most strongly (i.e., with highest perceptual strength rating).
+Zhong-2022-664	PERCEPTUAL_STRENGTH_MAX	numeric	sensory modality	maximum perceptual strength	ratings	users	zh		Perceptual strength in the dominant modality (i.e., highest strength rating across six perceptual modalities).
+Zhong-2022-664	PERCEPTUAL_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated perceptual strength	ratings	users	zh		Aggregated perceptual strength in all modalities where the influence of weaker modalities is attenuated, calculated as Minkowski distance (with exponent 3) of the 6-dimension vector of perceptual strength from the origin.
+Zhong-2022-664	PERCEPTUAL_STRENGTH_SUM	sum	sensory modality	perceptual strength	ratings	users	zh		This value represents the summarized perceptual strength.
+Zhong-2022-664	PERCEPTUAL_EXCLUSIVITY	percentage	sensory modality	exclusivity perceptual strength	ratings	users	zh		Modality exclusivity of the concept; the extent to which a concept is experienced through a single perceptual modality (0–1, typically expressed as %), calculated as the range of perceptual strength values divided by their sum.
+Zhong-2022-664	FOOT_ACTION_MEAN	mean	sensory modality	foot action strength	ratings	users	zh		Foot action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the foot / leg.
+Zhong-2022-664	HAND_ACTION_MEAN	mean	sensory modality	hand action strength	ratings	users	zh		Hand action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the hand / arm.
+Zhong-2022-664	MOUTH_ACTION_MEAN	mean	sensory modality	mouth action strength	ratings	users	zh		Mouth action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the mouth / throat.
+Zhong-2022-664	HEAD_ACTION_MEAN	mean	sensory modality	head action strength	ratings	users	zh		Head action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the head excluding mouth.
+Zhong-2022-664	TORSO_ACTION_MEAN	mean	sensory modality	torso action strength	ratings	users	zh		Torso action strength: mean rating (0–5) of how strongly the concept is experienced by performaing an action with the torso.
+Zhong-2022-664	ACTION_STRENGTH_MEAN	mean	sensory modality	action strength	ratings	users	zh		This value represents the mean action effector strength.
+Zhong-2022-664	ACTION_STRENGTH_SUM	sum	sensory modality	action strength	ratings	users	zh		This value represents the summarized action effector strength.
+Zhong-2022-664	ACTION_STRENGTH_MAX	numeric	sensory modality	maximum action strength	ratings	users	zh		Action strength in the dominant effector (i.e., highest strength rating across five action effectors).
+Zhong-2022-664	ACTION_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated action strength	ratings	users	zh		Aggregated action strength in all effectors where the influence of weaker effectors is attenuated, calculated as Minkowski distance (with exponent 3) of the 5-dimension vector of action strength from the origin.
+Zhong-2022-664	ACTION_EXCLUSIVITY	percentage	sensory modality	exclusivity action strength	ratings	users	zh		Effector exclusivity of the concept; the extent to which a concept is experienced through a single action effector (0–1, typically expressed as %), calculated as the range of action strength values divided by their sum.
+Zhong-2022-664	ACTION_DOMINANT	linguistic	sensory modality	dominant action strength	ratings	users	zh		Action effector through which the concept is experienced most strongly (i.e., with highest action strength rating).
+Zhong-2022-664	SENSORIMOTOR_STRENGTH_MAX	numeric	sensory modality	maximum sensorimotor strength	ratings	users	zh		Sensorimotor strength in the dominant dimension (i.e., highest strength rating across 11 sensorimotor dimensions).
+Zhong-2022-664	SENSORIMOTOR_DOMINANT	linguistic	sensory modality	dominant sensorimotor strength	ratings	users	zh		Sensorimotor dimension through which the concept is experienced most strongly (i.e., with highest sensorimotor strength rating).
+Zhong-2022-664	SENSORIMOTOR_STRENGTH_AGGREGATED	normalized	sensory modality	aggregated sensorimotor strength	ratings	users	zh		Aggregated sensorimotor strength in all dimensions where the influence of weaker dimensions is attenuated, calculated as Minkowski distance (with exponent 3) of the 11-dimension vector of sensorimotor strength from the origin.
+Zhong-2022-664	SENSORIMOTOR_STRENGTH_SUM	sum	sensory modality	sensorimotor strength	ratings	users	zh		This value represents the summarized sensorimotor strength in all dimensions.
+Zhong-2022-664	SENSORIMOTOR_EXCLUSIVITY	percentage	sensory modality	exclusivity sensorimotor strength	ratings	users	zh		Sensorimotor exclusivity of the concept; the extent to which a concept is experienced through a single sensorimotor dimension (0–1, typically expressed as %), calculated as the range of sensorimotor strength values divided by their sum.
+Zhong-2022-664	CONCRETE_ABSTRACT	linguistic	concrete/abstract		ratings	users	zh		This value represents the categorical distinction of whether the word is abstract or concrete.
+Jackson-2019-24	VALENCE	mean	valence		ratings	users	en		Valence ratings for emotion concepts based on a 10-point Likert scale.
+Jackson-2019-24	ACTIVATION	mean	arousal		ratings	users	en		Arousal ratings for emotion concepts based on a 10-point Likert scale.
+Jackson-2019-24	DOMINANCE	mean	dominance		ratings	users	en		Dominance ratings for emotion concepts based on a 10-point Likert scale.
+Jackson-2019-24	CERTAINTY	mean	certainty		ratings	users	en		Certainty ratings for emotion concepts based on a 10-point Likert scale.
+Jackson-2019-24	APPROACH_AVOIDANCE	mean	approach avoidance		ratings	users	en		Approach avoidance ratings for emotion concepts based on a 10-point Likert scale.
+Jackson-2019-24	SOCIALITY	mean	sociality		ratings	users	en		Sociality ratings for emotion concepts based on a 10-point Likert scale.
+Wang-2021-90	ISC_BRAIN_OBJNOBJ	numeric	intersubject consistency		norms	users	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask defined by contrasting object words with nonobject words.
+Wang-2021-90	ISC_BRAIN_WORDNEUROSYNTH	numeric	intersubject consistency	term word	norms	users	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask associated with the term word in the Neurosynth platform.
+Wang-2021-90	ISC_BRAIN_OBJEMONOBJNENOBJ	numeric	intersubject consistency	object contrast	norms	users	zh		Intersubject consistency (ISC) values from brain data, calculated from the brain mask defined by contrasting objects versus emotional nonobjects versus nonemotional nonobjects.
+Wang-2021-90	ISC_BRAIN_OBJNOBJ_LEAVE2_TOP300	numeric	intersubject consistency	individual-subject	norms	users	zh		Intersubject consistency (ISC) values from brain data, calculated from the individual-subject brain mask defined by contrasting object words with nonobject words; there were 300 voxels in each subject mask.
+Wang-2021-90	ISC_BEHAVIORAL	numeric	intersubject consistency	behavioral	norms	users	zh		Intersubject consistency (ISC) values from behavioral data.
+Wang-2021-90	SER_ZSCORE	standardized	sensory experience		ratings	users	zh		The averge of z-scores of language and sensory-experience rating means.
+Wang-2021-90	LANGUAGE_DESCRIPTIVENESS_MEAN	mean	descriptiveness		ratings	users	zh		The rating mean of language descriptiveness on a 7-point scale.
+Wang-2021-90	SER_MEAN	mean	sensory experience		ratings	users	zh		The rating mean of sensory experience on a 7-point scale.
+Wang-2021-90	NAVIGATION_MEAN	mean	navigation		ratings	users	zh		The rating mean of navigation on a 7-point scale.
+Wang-2021-90	MANIPULATION_MEAN	mean	sensory modality	manipulability	ratings	users	zh		The rating mean of manipulation on a 7-point scale.
+Wang-2021-90	STRESS_ACTION_MEAN	mean	action	stress-related	ratings	users	zh		The rating mean of stress-related action on a 7-point scale.
+Wang-2021-90	AROUSAL_MEAN	mean	arousal		ratings	users	zh		The rating mean of arousal on a 7-point scale.
+Wang-2021-90	VALENCE_MEAN	mean	valence		ratings	users	zh		The rating mean of emotional valence on a 7-point scale.
 Wang-2021-90	STROKE	cardinality	strokes		norms	meta	zh		Total number of strokes of the whole-word.
-Wang-2021-90	FAMILIARITY_MEAN	mean	familiarity		ratings	user	zh		The rating mean of familiarity on a 7-point scale.
+Wang-2021-90	FAMILIARITY_MEAN	mean	familiarity		ratings	users	zh		The rating mean of familiarity on a 7-point scale.
 List-2014-1280	COMMUNITY_LABEL	linguistic	polysemy	central concept	relations	concept lists	en		This is the most central node in each of the community clusters in CLICS1.
 List-2014-1280	COMMUNITY_ID	numeric	polysemy	community	relations	concept lists	en		This is the community identifier.
 List-2014-1280	COMMUNITY_URL	linguistic	polysemy	community	relations	concept lists	en		This is the community URL.
@@ -712,19 +712,19 @@ Ferre-2022-160	EMOTION_POLARITY	numeric	emotion	valence	ratings	users	en		Condit
 Ferre-2022-160	EMOTION_CONDITION	numeric	emotion	condition	ratings	users	en		Conditions regarding emotionality; 0 neutral words, 1 emotional words.
 Ferre-2022-160	ORTHOGRAPHIC_SIMILARITY	normalized	similarity	orthography	ratings	users	en		Normalized Levensthein Distance: Orthographic similarity between the English word and its Portuguese translation.
 Montefinese-2019-AoA	ITALIAN_AOA_MEAN	mean	AoA		ratings	users	it		The mean of age of acquisition ratings. Participants were asked to provide an approximate estimate of the age at which words have been learned in their written or spoken form for the first time.
-Speed-2024-Emotions	DUTCH_AROUSAL_MEAN	mean	arousal		ratings	user	nl		The mean value of the ratings for arousal on a 5-point scale (1 = very calm/passive, 5 = very excited/active).
-Speed-2024-Emotions	DUTCH_VALENCE_MEAN	mean	valence		ratings	user	nl		The mean value of the ratings for valence on a 5-point scale (1 = very negative/unpleasant, 5 = very positive/pleasant).
-Speed-2024-Emotions	DUTCH_VALENCE_CATEGORY	linguistic	emotion	strength	ratings	user	nl		The ratings of strength of valence on a 3-point scale (positive, negative, neutral).
-Speed-2024-Emotions	DUTCH_VALENCE_NEUTRAL	linguistic	emotion	strength	ratings	user	nl		The ratings of whether a term is valanced or neutral.
-Speed-2024-Emotions	DUTCH_HAPPINESS_MEAN	mean 	happiness		ratings	user	nl		The mean value of the ratings for discrete emotion "happiness" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_ANGER_MEAN	mean	anger		ratings	user	nl		The mean value of the ratings for discrete emotion "anger" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_FEAR_MEAN	mean	fear		ratings	user	nl		The mean value of the ratings for discrete emotion "fear" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_SADNESS_MEAN	mean	sadness		ratings	user	nl		The mean value of the ratings for discrete emotion "sadness" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_DISGUST_MEAN	mean	disgust		ratings	user	nl		The mean value of the ratings for discrete emotion "disgust" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_SURPRISE_MEAN	mean	surprise		ratings	user	nl		The mean value of the ratings for discrete emotion "surprise" on a 5-point scale (1 = not, 5 = very much).
-Speed-2024-Emotions	DUTCH_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	user	nl		The primary emotion most strongly related with the concept.
-Winter-2024-Iconicity	ENGLISH_KNOWN_PERCENTAGE	percentage	familiarity	known	ratings	user	en		The mean percentage of familiarity (pronunciation and meaning) of speakers with a term.
-Winter-2024-Iconicity	ENGLISH_ICONICITY_MEAN	mean	iconicity		ratings	user	en		The mean value of iconicity (i.e. they sound like what they mean) on a 7-point scale (1 = not iconic at all, 7 = very iconic).
+Speed-2024-Emotions	DUTCH_AROUSAL_MEAN	mean	arousal		ratings	users	nl		The mean value of the ratings for arousal on a 5-point scale (1 = very calm/passive, 5 = very excited/active).
+Speed-2024-Emotions	DUTCH_VALENCE_MEAN	mean	valence		ratings	users	nl		The mean value of the ratings for valence on a 5-point scale (1 = very negative/unpleasant, 5 = very positive/pleasant).
+Speed-2024-Emotions	DUTCH_VALENCE_CATEGORY	linguistic	emotion	strength	ratings	users	nl		The ratings of strength of valence on a 3-point scale (positive, negative, neutral).
+Speed-2024-Emotions	DUTCH_VALENCE_NEUTRAL	linguistic	emotion	strength	ratings	users	nl		The ratings of whether a term is valanced or neutral.
+Speed-2024-Emotions	DUTCH_HAPPINESS_MEAN	mean 	happiness		ratings	users	nl		The mean value of the ratings for discrete emotion "happiness" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_ANGER_MEAN	mean	anger		ratings	users	nl		The mean value of the ratings for discrete emotion "anger" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_FEAR_MEAN	mean	fear		ratings	users	nl		The mean value of the ratings for discrete emotion "fear" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_SADNESS_MEAN	mean	sadness		ratings	users	nl		The mean value of the ratings for discrete emotion "sadness" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_DISGUST_MEAN	mean	disgust		ratings	users	nl		The mean value of the ratings for discrete emotion "disgust" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_SURPRISE_MEAN	mean	surprise		ratings	users	nl		The mean value of the ratings for discrete emotion "surprise" on a 5-point scale (1 = not, 5 = very much).
+Speed-2024-Emotions	DUTCH_EMOTION_DOMINANT	linguistic	emotion	dominant	ratings	users	nl		The primary emotion most strongly related with the concept.
+Winter-2024-Iconicity	ENGLISH_KNOWN_PERCENTAGE	percentage	familiarity	known	ratings	users	en		The mean percentage of familiarity (pronunciation and meaning) of speakers with a term.
+Winter-2024-Iconicity	ENGLISH_ICONICITY_MEAN	mean	iconicity		ratings	users	en		The mean value of iconicity (i.e. they sound like what they mean) on a 7-point scale (1 = not iconic at all, 7 = very iconic).
 Vankrunkelsven-2024-SemanticGender	DUTCH_GENDER_MEAN_FEMALE	mean	gender association		ratings	users	nl		The mean rating of semantic gender provided by female participants on a 5-point scale (1 = very feminine, 2 = rather feminine, 3 = neutral, 4 = rather masculine, 5 = very masculine).
 Vankrunkelsven-2024-SemanticGender	DUTCH_GENDER_MEAN_MALE	mean	gender association		ratings	users	nl		The mean rating of semantic gender provided by male participants on a 5-point scale (1 = very feminine, 2 = rather feminine, 3 = neutral, 4 = rather masculine, 5 = very masculine).
 Vankrunkelsven-2024-SemanticGender	DUTCH_GENDER_MEAN	mean	gender association		ratings	users	nl		The mean rating of semantic gender on a 5-point scale (1 = very feminine, 2 = rather feminine, 3 = neutral, 4 = rather masculine, 5 = very masculine).


### PR DESCRIPTION
All instances of "user" in the rartings column of norare.tsv have been unified to "users".